### PR TITLE
URA-872 - handle failed uploads and resuming, more logging

### DIFF
--- a/example/example_config.json
+++ b/example/example_config.json
@@ -2,7 +2,7 @@
     "max_cores": 4,
     "max_threads": 8,
     "log_level": "INFO",
-    "log_dir": "",
+    "log_dir": "/var/log/s3_upload",
     "monitor": [
         {
             "monitored_directories": [

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -2,12 +2,12 @@ import argparse
 from os import cpu_count
 from pathlib import Path
 
-from .utils.upload import (
+from utils.upload import (
     check_aws_access,
     check_buckets_exist,
     multi_core_upload,
 )
-from .utils.utils import (
+from utils.utils import (
     check_is_sequencing_run_dir,
     check_termination_file_exists,
     get_runs_to_upload,
@@ -19,7 +19,7 @@ from .utils.utils import (
     verify_args,
     verify_config,
 )
-from .utils.log import get_logger
+from utils.log import get_logger
 
 
 log = get_logger("s3 upload")

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -19,7 +19,7 @@ from utils.utils import (
     verify_args,
     verify_config,
 )
-from utils.log import get_logger
+from utils.log import get_logger, set_file_handler
 
 
 log = get_logger("s3 upload")
@@ -241,6 +241,8 @@ def main() -> None:
     args = parse_args()
 
     if args.mode == "upload":
+        set_file_handler(log, "/var/log/s3_upload")
+        exit()
         upload_single_run(args)
     else:
         config = read_config(config=args.config)

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -13,6 +13,8 @@ from utils.utils import (
     get_runs_to_upload,
     get_sequencing_file_list,
     read_config,
+    read_upload_state_log,
+    write_upload_state_to_log,
     split_file_list_by_cores,
 )
 from utils.log import get_logger
@@ -241,7 +243,7 @@ def monitor_directories_for_upload(config):
         files = get_sequencing_file_list(run_config["run_dir"])
         files = split_file_list_by_cores(files=files, n=cores)
 
-        multi_core_upload(
+        uploaded_files, failed_upload = multi_core_upload(
             files=files,
             bucket=run_config["bucket"],
             remote_path=run_config["remote_path"],

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -241,12 +241,12 @@ def main() -> None:
     args = parse_args()
 
     if args.mode == "upload":
-        set_file_handler(log, "/var/log/s3_upload")
-        exit()
         upload_single_run(args)
     else:
         config = read_config(config=args.config)
         verify_config(config=config)
+
+        set_file_handler(log, config.get("log_dir", "/var/log/s3_upload"))
 
         monitor_directories_for_upload(config)
 

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -16,12 +16,29 @@ def get_console_handler():
     return console_handler
 
 
-def get_file_handler(log_file):
+def set_file_handler(logger, log_file) -> None:
+    check_write_permission_to_log_dir(Path(log_file).parent)
+
     file_handler = TimedRotatingFileHandler(
         log_file, when="midnight", backupCount=5
     )
     file_handler.setFormatter(FORMATTER)
-    return file_handler
+
+    logger.addHandler(file_handler)
+    # return file_handler
+
+
+# def set_file_handler(logger, log_file) -> None:
+#     """
+#     _summary_
+
+#     Parameters
+#     ----------
+#     logger : _type_
+#         _description_
+#     log_file : _type_
+#         _description_
+#     """
 
 
 def check_write_permission_to_log_dir(log_dir) -> None:
@@ -83,8 +100,6 @@ def get_logger(
         # logger already exists => use it
         return logging.getLogger(logger_name)
 
-    check_write_permission_to_log_dir(log_dir)
-
     log_file = os.path.join(log_dir, "s3_upload.log")
 
     Path(log_dir).mkdir(parents=True, exist_ok=True)
@@ -96,8 +111,6 @@ def get_logger(
         logger.setLevel(log_level)
 
     logger.addHandler(get_console_handler())
-    logger.addHandler(get_file_handler(log_file))
-
     logger.propagate = False
 
     logger.info("Initialised log handle, beginning logging to %s", log_file)

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -28,9 +28,11 @@ def set_file_handler(logger, log_dir) -> None:
     log_dir : str
         path to where to write log file to
     """
-    check_write_permission_to_log_dir(log_dir)
-
     log_file = os.path.join(log_dir, "s3_upload.log")
+
+    logger.info("setting log output to %s", log_file)
+
+    check_write_permission_to_log_dir(log_dir)
 
     file_handler = TimedRotatingFileHandler(
         log_file, when="midnight", backupCount=5

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -17,7 +17,17 @@ def get_console_handler():
 
 
 def set_file_handler(logger, log_dir) -> None:
-    print(log_dir)
+    """
+    Set the file handler to redirect all logs to log file `s3_upload.log`
+    in the specified directory
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        logging handler
+    log_dir : str
+        path to where to write log file to
+    """
     check_write_permission_to_log_dir(log_dir)
 
     log_file = os.path.join(log_dir, "s3_upload.log")
@@ -28,20 +38,6 @@ def set_file_handler(logger, log_dir) -> None:
     file_handler.setFormatter(FORMATTER)
 
     logger.addHandler(file_handler)
-    # return file_handler
-
-
-# def set_file_handler(logger, log_file) -> None:
-#     """
-#     _summary_
-
-#     Parameters
-#     ----------
-#     logger : _type_
-#         _description_
-#     log_file : _type_
-#         _description_
-#     """
 
 
 def check_write_permission_to_log_dir(log_dir) -> None:
@@ -60,8 +56,6 @@ def check_write_permission_to_log_dir(log_dir) -> None:
         Raised if path supplied is not writable
     """
     while log_dir:
-        print("foo")
-        print(log_dir)
         if not os.path.exists(log_dir):
             log_dir = Path(log_dir).parent
             continue

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -16,9 +16,9 @@ def get_console_handler():
     return console_handler
 
 
-def set_file_handler(logger, log_file) -> None:
-    print(log_file)
-    check_write_permission_to_log_dir(Path(log_file).parent)
+def set_file_handler(logger, log_dir) -> None:
+    print(log_dir)
+    check_write_permission_to_log_dir(log_dir)
 
     file_handler = TimedRotatingFileHandler(
         log_file, when="midnight", backupCount=5

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -17,6 +17,7 @@ def get_console_handler():
 
 
 def set_file_handler(logger, log_file) -> None:
+    print(log_file)
     check_write_permission_to_log_dir(Path(log_file).parent)
 
     file_handler = TimedRotatingFileHandler(
@@ -57,6 +58,8 @@ def check_write_permission_to_log_dir(log_dir) -> None:
         Raised if path supplied is not writable
     """
     while log_dir:
+        print("foo")
+        print(log_dir)
         if not os.path.exists(log_dir):
             log_dir = Path(log_dir).parent
             continue

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -20,6 +20,8 @@ def set_file_handler(logger, log_dir) -> None:
     print(log_dir)
     check_write_permission_to_log_dir(log_dir)
 
+    log_file = os.path.join(log_dir, "s3_upload.log")
+
     file_handler = TimedRotatingFileHandler(
         log_file, when="midnight", backupCount=5
     )

--- a/s3_upload/utils/upload.py
+++ b/s3_upload/utils/upload.py
@@ -145,8 +145,7 @@ def _submit_to_pool(pool, func, item_input, items, **kwargs):
 
     This has been abstracted from both multi_thread_upload and
     multi_core_upload to allow for unit testing of the called function
-    raising exceptions, which I could not figure out with the
-    ProcessPool submit calls being local to both functions.
+    raising exceptions that are caught and handled.
 
     In this context we will be calling upload_single_file() once for
     each of files in the given list of files, passing through the S3

--- a/s3_upload/utils/upload.py
+++ b/s3_upload/utils/upload.py
@@ -306,18 +306,6 @@ def multi_core_upload(
             threads=threads,
         )
 
-        # concurrent_jobs = {
-        #     exe.submit(
-        #         multi_thread_upload,
-        #         files=sub_files,
-        #         bucket=bucket,
-        #         remote_path=remote_path,
-        #         threads=threads,
-        #         parent_path=parent_path,
-        #     ): sub_files
-        #     for sub_files in files
-        # }
-
         for future in as_completed(concurrent_jobs):
             # access returned output as each is returned in any order
             try:

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -65,6 +65,33 @@ def check_is_sequencing_run_dir(run_dir) -> bool:
     return path.exists(path.join(run_dir, "RunInfo.xml"))
 
 
+def check_upload_state(sub_dir) -> str:
+    """
+    Checking upload state of run (i.e. uploaded, partial, new)
+
+    Parameters
+    ----------
+    sub_dir : str
+        name of directory to check upload state
+
+    Returns
+    -------
+    str
+        state of run upload, will be one of: uploaded, partial or new
+    """
+    upload_log = path.join("/var/log/s3_upload/uploads/", Path(sub_dir).name)
+
+    if not path.exists(upload_log):
+        return "new"
+
+    log_contents = read_upload_state_log(log_file=upload_log)
+
+    if log_contents["uploaded"]:
+        return "uploaded"
+    else:
+        return "partial"
+
+
 def get_runs_to_upload(monitor_dirs) -> list:
     """
     Get completed sequencing runs to upload from specified directories
@@ -132,33 +159,6 @@ def get_runs_to_upload(monitor_dirs) -> list:
                 to_upload.append(sub_dir)
 
     return to_upload, partially_uploaded
-
-
-def check_upload_state(sub_dir) -> str:
-    """
-    Checking upload state of run (i.e. uploaded, partial, new)
-
-    Parameters
-    ----------
-    sub_dir : str
-        name of directory to check upload state
-
-    Returns
-    -------
-    str
-        state of run upload, will be one of: uploaded, partial or new
-    """
-    upload_log = path.join("/var/log/s3_upload/uploads/", Path(sub_dir).name)
-
-    if not path.exists(upload_log):
-        return "new"
-
-    log_contents = read_upload_state_log(log_file=upload_log)
-
-    if log_contents["uploaded"]:
-        return "uploaded"
-    else:
-        return "partial"
 
 
 def get_sequencing_file_list(seq_dir, exclude_patterns=None) -> list:

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -210,6 +210,122 @@ def read_config(config) -> dict:
         return json.load(fh)
 
 
+def read_upload_state_log(log_file) -> bool:
+    """
+    Read upload state log to check if run has completed uploading
+
+    Parameters
+    ----------
+    log_file : str
+        path to upload state log for run
+
+    Returns
+    -------
+    bool
+        True if run has completed uploading else False
+    """
+    log.info("Reading upload state from log file: %s", log_file)
+
+    with open(log_file) as fh:
+        log_data = json.loads(fh)
+
+    uploaded = (
+        "finished upload" if log_data["completed"] else "incomplete upload"
+    )
+
+    log.info("state of run %s: %s", log_data["run_id"], uploaded)
+
+    if not log_data["completed"]:
+        log.info(
+            "total local files: %s | total uploaded files: %s | total failed"
+            " upload: %s | total files to upload %s",
+            log_data["total_local_files"],
+            log_data["total_uploaded_files"],
+            log_data["total_failed_upload"],
+            log_data["total_local_files"] - log_data["total_uploaded_files"],
+        )
+
+    return log_data["completed"]
+
+
+def write_upload_state_to_log(
+    run_id, run_path, log_file, local_files, uploaded_files, failed_files
+) -> dict:
+    """
+    Write the log file for the run to log the state of what has been uploaded.
+
+    If the uploaded files matches the local files with no failed uploads,
+    the run is marked as complete uploaded. This is then used for future
+    monitoring to know not to attempt re-upload.
+
+    Parameters
+    ----------
+    run_id : str
+        ID of sequencing run
+    run_path : str
+        path to run directory being uploaded
+    log_file : str
+        file to write log to
+    local_files : list[list]
+        list of list of local files provided to upload
+    uploaded_files : dict
+        mapping of uploaded local file path to remote object ID
+    failed_files : list
+        list of files that failed to upload
+
+    Returns
+    -------
+    dict
+        all log data for the run
+    """
+    total_local_files = len([x for y in local_files for x in y])
+    total_uploaded_files = len(uploaded_files.keys())
+    total_failed_files = len(failed_files)
+
+    log.info("logging upload state of %s", run_id)
+    log.info(
+        "total local files: %s | total uploaded files: %s | total failed"
+        " upload: %s",
+        total_local_files,
+        total_uploaded_files,
+        total_failed_files,
+    )
+
+    if path.exists(log_file):
+        # log file already exists => continuing previous failed upload
+        log.debug("log file already exists at %s", log_file)
+
+        with open(log_file, "r") as fh:
+            log_data = json.load(fh)
+    else:
+        log_data = {
+            "run_id": run_id,
+            "run path": run_path,
+            "completed": False,
+            "total_local_files": total_local_files,
+            "total_uploaded_files": 0,
+            "total_failed_upload": 0,
+            "failed_upload_files": [],
+            "uploaded_files": {},
+        }
+
+    log_data["total_uploaded_files"] += total_uploaded_files
+    log_data["total_failed_upload"] = total_failed_files
+    log_data["failed_upload_files"] = failed_files
+    log_data["uploaded_files"] = {
+        **log_data["uploaded_files"],
+        **uploaded_files,
+    }
+
+    if total_failed_files == 0 and total_local_files == total_uploaded_files:
+        log.info(
+            "All files uploaded and no files failed, run completed uploading"
+        )
+        log_data["completed"] = True
+
+    return log_data
+
+
 def sizeof_fmt(num) -> str:
     """
     Function to turn bytes to human readable file size format.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,7 +103,7 @@ class TestReadUploadStateLog(unittest.TestCase):
     ):
         mock_exists.return_value = False
 
-        upload_state = utils.check_upload_state(
+        upload_state, uploaded_files = utils.check_upload_state(
             sub_dir="/some/path/to/test_run"
         )
 
@@ -115,6 +115,9 @@ class TestReadUploadStateLog(unittest.TestCase):
         with self.subTest("correct string returned"):
             self.assertEqual(upload_state, "new")
 
+        with self.subTest("empty file list returned"):
+            self.assertEqual(uploaded_files, [])
+
     def test_uploaded_returned_for_run_that_has_uploaded(
         self, mock_log, mock_exists
     ):
@@ -124,13 +127,18 @@ class TestReadUploadStateLog(unittest.TestCase):
             "run_id": "test_run",
             "run_path": "/some/path/to/test_run",
             "uploaded": True,
+            "uploaded_files": {"file1.txt": "abc123", "file2.txt": "def456"},
         }
 
-        upload_state = utils.check_upload_state(
+        upload_state, uploaded_files = utils.check_upload_state(
             sub_dir="/some/path/to/test_run"
         )
 
-        self.assertEqual(upload_state, "uploaded")
+        with self.subTest("uploaded run correctly returned"):
+            self.assertEqual(upload_state, "uploaded")
+
+        with self.subTest("correct file list returned"):
+            self.assertEqual(uploaded_files, ["file1.txt", "file2.txt"])
 
     def test_partial_returned_for_run_that_has_not_fully_uploaded(
         self, mock_log, mock_exists
@@ -141,13 +149,18 @@ class TestReadUploadStateLog(unittest.TestCase):
             "run_id": "test_run",
             "run_path": "/some/path/to/test_run",
             "uploaded": False,
+            "uploaded_files": {"file1.txt": "abc123", "file2.txt": "def456"},
         }
 
-        upload_state = utils.check_upload_state(
+        upload_state, uploaded_files = utils.check_upload_state(
             sub_dir="/some/path/to/test_run"
         )
 
-        self.assertEqual(upload_state, "partial")
+        with self.subTest("partial correctly returned"):
+            self.assertEqual(upload_state, "partial")
+
+        with self.subTest("correct file list returned"):
+            self.assertEqual(uploaded_files, ["file1.txt", "file2.txt"])
 
 
 class TestGetRunsToUpload(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -190,7 +190,7 @@ class TestGetRunsToUpload(unittest.TestCase):
             )
             open(test_file, "w").close()
 
-        returned_upload_dirs = utils.get_runs_to_upload(
+        returned_upload_dirs, _ = utils.get_runs_to_upload(
             monitor_dirs=[
                 os.path.join(TEST_DATA_DIR, "seq1"),
                 os.path.join(TEST_DATA_DIR, "seq2"),
@@ -366,14 +366,14 @@ class TestGetSequencingFileList(unittest.TestCase):
 
 class TestFilterUploadedFiles(unittest.TestCase):
     def test_correct_file_list_returned(self):
-        local_files = ['file1.txt', 'file2.txt', 'file3.txt']
-        uploaded_files = ['file1.txt', 'file2.txt']
+        local_files = ["file1.txt", "file2.txt", "file3.txt"]
+        uploaded_files = ["file1.txt", "file2.txt"]
 
         to_upload = utils.filter_uploaded_files(
             local_files=local_files, uploaded_files=uploaded_files
         )
 
-        self.assertEqual(to_upload, ['file3.txt'])
+        self.assertEqual(to_upload, ["file3.txt"])
 
 
 class TestSplitFileListByCores(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,7 +97,7 @@ class TestCheckIsSequencingRunDir(unittest.TestCase):
 
 @patch("s3_upload.utils.utils.path.exists")
 @patch("s3_upload.utils.utils.read_upload_state_log")
-class TestReadUploadStateLog(unittest.TestCase):
+class TestCheckUploadState(unittest.TestCase):
     def test_new_returned_when_upload_log_does_not_exist(
         self, mock_log, mock_exists
     ):
@@ -362,6 +362,18 @@ class TestGetSequencingFileList(unittest.TestCase):
                 self.assertEqual(
                     sorted(returned_file_list), sorted(expected_files)
                 )
+
+
+class TestFilterUploadedFiles(unittest.TestCase):
+    def test_correct_file_list_returned(self):
+        local_files = ['file1.txt', 'file2.txt', 'file3.txt']
+        uploaded_files = ['file1.txt', 'file2.txt']
+
+        to_upload = utils.filter_uploaded_files(
+            local_files=local_files, uploaded_files=uploaded_files
+        )
+
+        self.assertEqual(to_upload, ['file3.txt'])
 
 
 class TestSplitFileListByCores(unittest.TestCase):


### PR DESCRIPTION
## Summary
Various changes to handle part uploaded runs and resuming upload on rerunning through logging of uploaded and failed files

## Changes
- behaviour:
  - handling of retrying previously failed uploads added to `s3_upload.monitor_directories_for_upload`, this will read through any run log files for previous incomplete uploads and preferentially start uploading those
  - submitting of concurrent jobs in both `upload.multi_thread_upload` and `upload.multi_core_upload` abstracted to `upload._submit_to_pool` to allow for patching in the mapping of Future object to file for unit testing
  - `disable_request_compression` set to `True` in the config for the s3 session client
   - since the largest files in a run are bcls and these will not compress, this significantly reduces CPU load and peak memory usage that is not needed
- lots of unit testing added for new changes (not all fully covered - will be in another PR) 

- new functions:
  - `utils.check_upload_state`: reads through the per run log files to determine if a given run has been uploaded or not
  - `utils.filter_uploaded_files`: removes already uploaded files from local file list to give list of files to upload (i.e when resuming prior failed upload)
  - `utils.read_upload_state_log`: reads the upload log for given run to check if it has uploaded or not
  - `utils.write_upload_state_to_log`: writes out the per run structured log file that will be used for determing if a run has completed uploading or not
  - `log.set_file_handler`: setting of writing stdout/stderr logs to file separated to this function, allows for only outputting this log file in monitor mode and not single upload
  - `upload._submit_to_pool` - abstraction of the `ThreadPoolExecutor` and `ProcessPoolExecutor` job submission to allow for testing
  
