### PR TITLE
URA-872 - filter runs by assay

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Monitoring of specified directories for sequencing runs to upload are defined in
 * `monitored_directories` (list): list of absolute paths to directories to monitor for new sequencing runs (i.e the location the sequencer outputs to)
 * `bucket` (str): name of S3 bucket to upload to
 * `remote_path` (str): parent path in which to upload sequencing run directories in the specified bucket
+* `sample_regex` (str | optional): regex pattern to match against all samples parsed from the samplesheet, all samples must match this pattern to upload the run. This is to be used for controlling upload of specific runs where samplenames inform the assay / test.
 
 Each dictionary inside of the list to monitor allows for setting separate upload locations for each of the monitored directories. For example, in the below example the output of both `sequencer_1` and `sequencer_2` would be uploaded to the root of `bucket_A`, and the output of `sequencer_3` would be uploaded into `sequencer_3_runs` in `bucket_B`. Any number of these dictionaries may be defined in the monitor list.
 
@@ -57,7 +58,8 @@ Each dictionary inside of the list to monitor allows for setting separate upload
                 "/absolute/path/to/sequencer_2"
             ],
             "bucket": "bucket_A",
-            "remote_path": "/"
+            "remote_path": "/",
+            "sample_regex": "_assay_1_code_|_assay_code_2_"
         },
         {
             "monitored_directories": [

--- a/example/example_config.json
+++ b/example/example_config.json
@@ -10,7 +10,8 @@
                 "/absolute/path/to/sequencer_2"
             ],
             "bucket": "bucket_A",
-            "remote_path": "/"
+            "remote_path": "/",
+            "sample_regex": "_assay_1_code_|_assay_code_2_"
         },
         {
             "monitored_directories": [

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -22,7 +22,7 @@ from utils.utils import (
 from utils.log import get_logger, set_file_handler
 
 
-log = get_logger("s3 upload")
+log = get_logger("s3_upload")
 
 
 def parse_args() -> argparse.Namespace:

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -15,7 +15,6 @@ from utils.utils import (
     get_runs_to_upload,
     get_sequencing_file_list,
     filter_uploaded_files,
-    read_config,
     split_file_list_by_cores,
     verify_args,
     verify_config,
@@ -159,7 +158,9 @@ def monitor_directories_for_upload(config):
     # and build a dict per run with config of where to upload
     for monitor_dir_config in config["monitor"]:
         completed_runs, partially_uploaded = get_runs_to_upload(
-            monitor_dir_config["monitored_directories"], log_dir=log_dir
+            monitor_dir_config.get("monitored_directories"),
+            log_dir=log_dir,
+            sample_pattern=monitor_dir_config.get("sample_regex"),
         )
 
         for run_dir in completed_runs:

--- a/s3_upload/utils/io.py
+++ b/s3_upload/utils/io.py
@@ -65,7 +65,13 @@ def read_samplesheet_from_run_directory(run_dir) -> Union[list, None]:
 
     log.info("Found the following samplesheet(s): %s", ", ".join(files))
 
-    all_files_contents = [Path(x).read_text().split("\n") for x in files]
+    # read all files in, split lines to lists and ensure trailing new line
+    # dropped to not result in empty string in list
+    all_files_contents = [Path(x).read_text() for x in files]
+
+    all_files_contents = [
+        re.sub(r"\n$", "", x).split("\n") for x in all_files_contents
+    ]
 
     if not all([all_files_contents[0] == x for x in all_files_contents]):
         log.error(

--- a/s3_upload/utils/upload.py
+++ b/s3_upload/utils/upload.py
@@ -17,7 +17,7 @@ from botocore import exceptions as s3_exceptions
 from .log import get_logger
 
 
-log = get_logger("s3 upload")
+log = get_logger("s3_upload")
 
 
 def check_aws_access():

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -124,11 +124,6 @@ def check_all_uploadable_samples(
         True if all sample names match the regex, else False. None returned
         if no samplenames are returned from the call to
         get_samplenames_from_samplesheet.
-
-    Raises
-    ------
-    re.error
-        Raised when provided regex pattern is invalid
     """
     log.info(
         "Checking if sample names match provided pattern(s) from config: %s",
@@ -142,14 +137,6 @@ def check_all_uploadable_samples(
     if not sample_names:
         log.warning("Failed parsing samplenames from samplesheet")
         return None
-
-    try:
-        re.compile(sample_pattern)
-    except re.error as err:
-        log.error(
-            "Invalid regex pattern provided from config: %s", sample_pattern
-        )
-        raise err
 
     return all([re.search(sample_pattern, x) for x in sample_names])
 
@@ -453,6 +440,15 @@ def verify_config(config) -> None:
                         f"{idx}. Expected: {expected_type} | Found "
                         f"{type(monitor.get(key))}"
                     )
+
+        if monitor.get("sample_regex"):
+            try:
+                re.compile(monitor.get("sample_regex"))
+            except Exception:
+                errors.append(
+                    "Invalid regex pattern provided in monitor section "
+                    f"{idx}: {monitor.get('sample_regex')}"
+                )
 
     if errors:
         error_message = (

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -21,6 +21,7 @@ class TestReadSamplesheet(unittest.TestCase):
 
     @patch("s3_upload.utils.io.Path")
     def test_samplesheet_regex_finds_expected_files(self, mock_path, mock_dir):
+        """Test when single valid samplesheet found we return the contents"""
         samplesheets = [
             "SAMPLESHEET.CSV",
             "SampleSheet.csv",
@@ -44,6 +45,9 @@ class TestReadSamplesheet(unittest.TestCase):
                 self.assertEqual(contents, ["foo", "bar"])
 
     def test_not_samplesheets_do_not_get_selected_by_regex(self, mock_dir):
+        """
+        Test if no samplesheet is found against the regex that we return None
+        """
         not_samplesheets = [
             "my_file.csv",
             "SampleSheet.txt",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,6 +12,87 @@ from tests import TEST_DATA_DIR
 from s3_upload.utils import io
 
 
+@patch("s3_upload.utils.io.listdir")
+class TestReadSamplesheet(unittest.TestCase):
+    def test_no_samplesheet_returns_none(self, mock_dir):
+        contents = io.read_samplesheet_from_run_directory(TEST_DATA_DIR)
+
+        self.assertEqual(contents, None)
+
+    @patch("s3_upload.utils.io.Path")
+    def test_samplesheet_regex_finds_expected_files(self, mock_path, mock_dir):
+        samplesheets = [
+            "SAMPLESHEET.CSV",
+            "SampleSheet.csv",
+            "Samplesheet.csv",
+            "samplesheet.csv",
+            "experiment_1_samplesheet.csv",
+            "experiment_2_SampleSheet.csv",
+            "experiment_3-samplesheet_attempt_1.csv",
+        ]
+
+        for samplesheet in samplesheets:
+            # mock finding single samplesheet for each name in given dir
+            mock_dir.return_value = [samplesheet]
+            mock_path.return_value.read_text.return_value = "foo\nbar"
+
+            with self.subTest(f"checking regex with {samplesheet}"):
+                contents = io.read_samplesheet_from_run_directory(
+                    TEST_DATA_DIR
+                )
+
+                self.assertEqual(contents, ["foo", "bar"])
+
+    def test_not_samplesheets_do_not_get_selected_by_regex(self, mock_dir):
+        not_samplesheets = [
+            "my_file.csv",
+            "SampleSheet.txt",
+            "samplesheet.tsv",
+            "Samplesheet.xlsx",
+            "samplesheet",
+            "sample_1.csv",
+        ]
+
+        for not_a_samplesheet in not_samplesheets:
+            # mock finding single samplesheet for each name in given dir
+            mock_dir.return_value = [not_a_samplesheet]
+
+            with self.subTest(f"checking regex with {not_a_samplesheet}"):
+                contents = io.read_samplesheet_from_run_directory(
+                    TEST_DATA_DIR
+                )
+
+                self.assertEqual(contents, None)
+
+    @patch("s3_upload.utils.io.Path")
+    def test_two_samplesheets_with_same_contents_returns_contents(
+        self, mock_path, mock_dir
+    ):
+        mock_dir.return_value = ["samplesheet1.csv", "samplesheet2.csv"]
+
+        mock_path.return_value.read_text.side_effect = [
+            "foo\nbar",
+            "foo\nbar",
+        ]
+        contents = io.read_samplesheet_from_run_directory(TEST_DATA_DIR)
+
+        self.assertEqual(contents, ["foo", "bar"])
+
+    @patch("s3_upload.utils.io.Path")
+    def test_two_samplesheets_with_different_contents_returns_none(
+        self, mock_path, mock_dir
+    ):
+        mock_dir.return_value = ["samplesheet1.csv", "samplesheet2.csv"]
+
+        mock_path.return_value.read_text.side_effect = [
+            "foo\nbar",
+            "baz\nblarg",
+        ]
+        contents = io.read_samplesheet_from_run_directory(TEST_DATA_DIR)
+
+        self.assertEqual(contents, None)
+
+
 @patch("s3_upload.utils.io.path.exists")
 class TestWriteUploadStateToLog(unittest.TestCase):
     def tearDown(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,6 +165,10 @@ class TestCheckUploadState(unittest.TestCase):
             self.assertEqual(uploaded_files, ["file1.txt", "file2.txt"])
 
 
+class TestCheckAllUploadableSamples(unittest.TestCase):
+    pass
+
+
 class TestGetRunsToUpload(unittest.TestCase):
     def test_uploadable_directories_correctly_returned(self):
         # TODO - add additional tests to cover calling of check_upload_state
@@ -365,6 +369,75 @@ class TestGetSequencingFileList(unittest.TestCase):
                 self.assertEqual(
                     sorted(returned_file_list), sorted(expected_files)
                 )
+
+
+class TestGetSamplenamesFromSamplesheet(unittest.TestCase):
+    samplesheet_contents = [
+        "[Header],,,,,,",
+        "IEMFileVersion,5,,,,,",
+        "Investigator Name,,,,,,",
+        "Experiment Name,,,,,,",
+        "Date,28/02/2024,,,,,",
+        "Workflow,GenerateFASTQ,,,,,",
+        "Application,NovaSeq FASTQ Only,,,,,",
+        "Instrument Type,NovaSeq,,,,,",
+        "Assay,TruSeq,,,,,",
+        "Index Adapters,96_UDI_PN101308,,,,,",
+        ",,,,,,",
+        "[Reads],,,,,,",
+        "151,,,,,,",
+        "151,,,,,,",
+        ",,,,,,",
+        "[Settings],,,,,,",
+        "Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA,,,,,",
+        "AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT,,,,,",
+        ",,,,,,",
+        "[Data],,,,,,",
+        "Sample_ID,Sample_Name,Sample_Plate,Sample_Well,Index_Plate_Well,index,index2",
+        "sample_a,sample_a,820,A7,A07,ACCAATCTCG,AGTGCCGGAA",
+        "sample_b,sample_b,820,B7,B07,GTCGTGACAC,AGCCATACAA",
+        "sample_c,sample_c,820,C7,C07,TCTCTAGTCG,AATCGATCCA",
+        "sample_d,sample_d,820,D7,D07,ATTACGGTTG,GGTGATTCCG",
+        "sample_e,sample_e,820,E7,E07,CGGTAAGTAA,TAGATAGCTC",
+    ]
+
+    def test_sample_names_correctly_returned(self):
+        parsed_names = utils.get_samplenames_from_samplesheet(
+            contents=self.samplesheet_contents
+        )
+
+        expected_names = [
+            "sample_a",
+            "sample_b",
+            "sample_c",
+            "sample_d",
+            "sample_e",
+        ]
+
+        self.assertEqual(parsed_names, expected_names)
+
+    def test_none_returned_if_sample_id_line_missing_from_samplesheet(self):
+        contents = self.samplesheet_contents.copy()
+        contents = [x for x in contents if not x.startswith("Sample_ID")]
+
+        parsed_names = utils.get_samplenames_from_samplesheet(
+            contents=contents
+        )
+
+        self.assertEqual(parsed_names, None)
+
+    def test_none_returned_if_multiple_sample_id_lines_present(self):
+        contents = self.samplesheet_contents.copy()
+        contents.append(
+            "Sample_ID,Sample_Name,Sample_Plate,Sample_Well,"
+            "Index_Plate_Well,index,index2"
+        )
+
+        parsed_names = utils.get_samplenames_from_samplesheet(
+            contents=contents
+        )
+
+        self.assertEqual(parsed_names, None)
 
 
 class TestFilterUploadedFiles(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -315,41 +315,6 @@ class TestGetRunsToUpload(unittest.TestCase):
 
         rmtree(sequencer_output_dir)
 
-    def test_complete_sequencing_runs_are_skipped(self):
-        """
-        Incomplete run determined from presence of just having RunInfo.xml
-        file and no termination files
-        """
-        sequencer_output_dir = os.path.join(TEST_DATA_DIR, uuid4().hex)
-        ongoing_run = os.path.join(
-            sequencer_output_dir, "16102023_A01295_001_ABC123"
-        )
-        os.makedirs(
-            ongoing_run,
-            exist_ok=True,
-        )
-        open(os.path.join(ongoing_run, "RunInfo.xml"), "w").close()
-
-        to_upload, partial_upload = utils.get_runs_to_upload(
-            [sequencer_output_dir]
-        )
-
-        with self.subTest("testing outputs are empty"):
-            self.assertTrue(to_upload == [] and partial_upload == {})
-
-        with self.subTest("testing log message"):
-            with self.assertLogs("s3_upload", level="DEBUG") as log:
-                utils.get_runs_to_upload([sequencer_output_dir])
-
-                expected_log_message = (
-                    f"{ongoing_run} has not completed sequencing and will not"
-                    " be uploaded"
-                )
-
-                self.assertTrue(expected_log_message in "".join(log.output))
-
-        rmtree(sequencer_output_dir)
-
     @patch("s3_upload.utils.utils.check_upload_state")
     @patch("s3_upload.utils.utils.check_all_uploadable_samples")
     @patch("s3_upload.utils.utils.read_samplesheet_from_run_directory")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -608,18 +608,20 @@ class TestVerifyConfig(unittest.TestCase):
                     ],
                     "bucket": 1,
                     "remote_path": "/sequencer_3_runs",
+                    "sample_regex": "[assay_1",
                 },
             ],
         }
 
         expected_errors = (
-            "6 errors found in config:\n\tmax_cores must be an"
+            "7 errors found in config:\n\tmax_cores must be an"
             " integer\n\tmax_threads must be an integer\n\trequired parameter"
             " log_dir not defined\n\trequired parameter monitored_directories"
             " missing from monitor section 0\n\trequired parameter remote_path"
             " missing from monitor section 0\n\tbucket not of expected type"
             " from monitor section 1. Expected: <class 'str'> | Found <class"
-            " 'int'>"
+            " 'int'>\n\tInvalid regex pattern provided in monitor section 1:"
+            " [assay_1"
         )
 
         with pytest.raises(RuntimeError, match=re.escape(expected_errors)):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 import re
 from shutil import rmtree
 from uuid import uuid4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,8 +165,51 @@ class TestCheckUploadState(unittest.TestCase):
             self.assertEqual(uploaded_files, ["file1.txt", "file2.txt"])
 
 
+@patch("s3_upload.utils.utils.get_samplenames_from_samplesheet")
 class TestCheckAllUploadableSamples(unittest.TestCase):
-    pass
+    def test_all_matching_samples_returns_true(self, mock_get_names):
+        mock_get_names.return_value = [
+            "sample_a_assay_1",
+            "sample_b_assay_1",
+            "sample_c_assay_1",
+        ]
+
+        self.assertTrue(utils.check_all_uploadable_samples([], "assay_1"))
+
+    def test_all_matching_samples_returns_true_with_multiple_patterns(
+        self, mock_get_names
+    ):
+        """
+        Test if we have mixed runs and always want to upload against multiple
+        patterns in a single regex
+        """
+        mock_get_names.return_value = [
+            "sample_a_assay_1",
+            "sample_b_assay_2",
+            "sample_c_assay_3",
+        ]
+
+        self.assertTrue(
+            utils.check_all_uploadable_samples([], "assay_1|assay_2|assay_3")
+        )
+
+    def test_no_matching_samples_returns_false(self, mock_get_names):
+        mock_get_names.return_value = [
+            "sample_a_assay_1",
+            "sample_b_assay_1",
+            "sample_c_assay_1",
+        ]
+
+        self.assertFalse(utils.check_all_uploadable_samples([], "assay_2"))
+
+    def test_parial_matching_samples_returns_false(self, mock_get_names):
+        mock_get_names.return_value = [
+            "sample_a_assay_1",
+            "sample_b_assay_2",
+            "sample_c_assay_3",
+        ]
+
+        self.assertFalse(utils.check_all_uploadable_samples([], "assay_2"))
 
 
 class TestGetRunsToUpload(unittest.TestCase):


### PR DESCRIPTION
## Summary
Adds ability to filter runs to upload by matching all samples against the key `sample_regex` from the config.
Closes #8 

## Changes
- new functions
  - `io.read_samplesheet_from_run_directory` - handles finding and reading in contents of samplesheet
  - `utils.check_all_uploadable_samples` - compares the `sample_regex` against sample names to determine if to upload the run
  - `utils.get_sample_names_from_samplesheet` - parses the samplenames section from the samplesheet contents
- add additional config check in `utils.verify_config` for valid regex patterns
- add lots of unit tests for new functionality

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/16)
<!-- Reviewable:end -->
