### PR TITLE
URA-872 - add --dry_run arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Available inputs for `upload`:
 
 Available inputs for `monitor`:
 * `--config`: path to JSON config file for monitoring (see below)
+* `--dry_run` (optional): calls everything except the actual upload to check what runs would be uploaded
 
 ## Config
 

--- a/s3_upload/utils/io.py
+++ b/s3_upload/utils/io.py
@@ -6,7 +6,7 @@ from typing import Union
 
 from .log import get_logger
 
-log = get_logger("s3 upload")
+log = get_logger("s3_upload")
 
 
 def read_config(config) -> dict:
@@ -103,7 +103,7 @@ def read_upload_state_log(log_file) -> dict:
     log.debug("Reading upload state from log file: %s", log_file)
 
     with open(log_file) as fh:
-        log_data = json.loads(fh)
+        log_data = json.load(fh)
 
     uploaded = (
         "finished upload" if log_data["completed"] else "incomplete upload"

--- a/tests/test_data/complete_run_upload.log.json
+++ b/tests/test_data/complete_run_upload.log.json
@@ -1,6 +1,6 @@
 {
     "run_id": "181024_A01295_001_ABC123",
-    "run path": "/genetics/181024_A01295_001_ABC123",
+    "run_path": "/genetics/181024_A01295_001_ABC123",
     "completed": true,
     "total_local_files": 2,
     "total_uploaded_files": 2,

--- a/tests/test_data/complete_run_upload.log.json
+++ b/tests/test_data/complete_run_upload.log.json
@@ -1,0 +1,13 @@
+{
+    "run_id": "181024_A01295_001_ABC123",
+    "run path": "/genetics/181024_A01295_001_ABC123",
+    "completed": true,
+    "total_local_files": 2,
+    "total_uploaded_files": 2,
+    "total_failed_upload": 0,
+    "failed_upload_files": [],
+    "uploaded_files": {
+        "file1.txt": "abc123",
+        "file2.txt": "def456"
+    }
+}

--- a/tests/test_data/incomplete_run_upload.log.json
+++ b/tests/test_data/incomplete_run_upload.log.json
@@ -1,6 +1,6 @@
 {
     "run_id": "181024_A01295_001_ABC123",
-    "run path": "/genetics/181024_A01295_001_ABC123",
+    "run_path": "/genetics/181024_A01295_001_ABC123",
     "completed": false,
     "total_local_files": 2,
     "total_uploaded_files": 1,

--- a/tests/test_data/incomplete_run_upload.log.json
+++ b/tests/test_data/incomplete_run_upload.log.json
@@ -1,0 +1,12 @@
+{
+    "run_id": "181024_A01295_001_ABC123",
+    "run path": "/genetics/181024_A01295_001_ABC123",
+    "completed": false,
+    "total_local_files": 2,
+    "total_uploaded_files": 1,
+    "total_failed_upload": 0,
+    "failed_upload_files": [],
+    "uploaded_files": {
+        "file1.txt": "abc123"
+    }
+}

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -112,6 +112,43 @@ class TestReadSamplesheetFromRunDirectory(unittest.TestCase):
         self.assertEqual(contents, expected_contents)
 
 
+class TestReadUploadStateLog(unittest.TestCase):
+    def test_file_contents_returned_correctly(self):
+        upload_log = os.path.join(
+            TEST_DATA_DIR, "complete_run_upload.log.json"
+        )
+
+        read_contents = io.read_upload_state_log(upload_log)
+
+        expected_contents = {
+            "run_id": "181024_A01295_001_ABC123",
+            "run path": "/genetics/181024_A01295_001_ABC123",
+            "completed": True,
+            "total_local_files": 2,
+            "total_uploaded_files": 2,
+            "total_failed_upload": 0,
+            "failed_upload_files": [],
+            "uploaded_files": {"file1.txt": "abc123", "file2.txt": "def456"},
+        }
+
+        self.assertDictEqual(read_contents, expected_contents)
+
+    def test_incomplete_upload_displays_correct_debug_log(self):
+        upload_log = os.path.join(
+            TEST_DATA_DIR, "incomplete_run_upload.log.json"
+        )
+
+        with self.assertLogs("s3_upload", level="DEBUG") as log:
+            io.read_upload_state_log(upload_log)
+
+            expected_log_message = (
+                "total local files: 2 | total uploaded files: 1 | total"
+                " failed upload: 0 | total files to upload 1"
+            )
+
+            self.assertIn(expected_log_message, "".join(log.output))
+
+
 @patch("s3_upload.utils.io.path.exists")
 class TestWriteUploadStateToLog(unittest.TestCase):
     def tearDown(self):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -122,7 +122,7 @@ class TestReadUploadStateLog(unittest.TestCase):
 
         expected_contents = {
             "run_id": "181024_A01295_001_ABC123",
-            "run path": "/genetics/181024_A01295_001_ABC123",
+            "run_path": "/genetics/181024_A01295_001_ABC123",
             "completed": True,
             "total_local_files": 2,
             "total_uploaded_files": 2,


### PR DESCRIPTION
- add `--dry_run` argument to monitor mode to run without actually triggering the upload
- add tests to `TestReadUploadStateLog`
- fix bug in `io.read_upload_state_log`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/18)
<!-- Reviewable:end -->
