### PR TITLE
URA-872 - fix bug in single run upload

### DIFF
--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -120,7 +120,7 @@ def upload_single_run(args):
         parsed command line arguments
     """
     check_aws_access()
-    check_buckets_exist(args.bucket)
+    check_buckets_exist([args.bucket])
 
     if not check_is_sequencing_run_dir(
         args.local_path

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -139,6 +139,9 @@ def upload_single_run(args):
     # to ensure we upload into the actual run directory
     parent_path = Path(args.local_path).parent
 
+    # simple timer of upload
+    start = timer()
+
     multi_core_upload(
         files=files,
         bucket=args.bucket,
@@ -146,6 +149,15 @@ def upload_single_run(args):
         cores=args.cores,
         threads=args.threads,
         parent_path=parent_path,
+    )
+
+    end = timer()
+    total = end - start
+
+    log.info(
+        "Uploaded %s in %s",
+        args.local_path,
+        f"{int(total // 60)}m {int(total % 60)}s",
     )
 
 


### PR DESCRIPTION
- fix bug in single run upload where S3 bucket requires being passed to `upload.check_buckets_exist` as a list and not a string
- add a simple timer to single run upload for logging total upload time

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/33)
<!-- Reviewable:end -->
