### PR TITLE
URA-872 - AWS authentication via access keys

### DIFF
--- a/.github/workflows/e2e_test_reminder.yaml
+++ b/.github/workflows/e2e_test_reminder.yaml
@@ -1,0 +1,26 @@
+name: e2e test reminder comment
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  comment-in-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: ':warning: Reminder to manually run end to end tests in https://github.com/eastgenomics/s3_upload/tree/main/tests/e2e'
+            })

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,23 +133,23 @@
         "filename": "tests/unit/test_upload.py",
         "hashed_secret": "6862b09f02f6db03961652bbac8b9934fc5ffad4",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 73
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/test_upload.py",
         "hashed_secret": "1c6408c43642afdf1c3f505035c56674c51c97e0",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 76
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/test_upload.py",
         "hashed_secret": "70aa317a8d9dac3b322870b8e2c84b410fcd310d",
         "is_verified": false,
-        "line_number": 157
+        "line_number": 183
       }
     ]
   },
-  "generated_at": "2024-11-07T14:39:28Z"
+  "generated_at": "2024-11-14T10:07:00Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -126,30 +122,6 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {
-    "tests/unit/test_upload.py": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "tests/unit/test_upload.py",
-        "hashed_secret": "6862b09f02f6db03961652bbac8b9934fc5ffad4",
-        "is_verified": false,
-        "line_number": 73
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "tests/unit/test_upload.py",
-        "hashed_secret": "1c6408c43642afdf1c3f505035c56674c51c97e0",
-        "is_verified": false,
-        "line_number": 76
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "tests/unit/test_upload.py",
-        "hashed_secret": "70aa317a8d9dac3b322870b8e2c84b410fcd310d",
-        "is_verified": false,
-        "line_number": 183
-      }
-    ]
-  },
-  "generated_at": "2024-11-14T10:07:00Z"
+  "results": {},
+  "generated_at": "2024-11-14T11:50:03Z"
 }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Each dictionary inside of the list to monitor allows for setting separate upload
 *Example `monitor` config section defining two sets of monitored directories and upload locations*
 
 
+## Authentication
+
+Authentication with AWS may be performed either via SSO / IAM or with specified access keys. If using SSO / IAM, it must first be configured using the [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html#sso-configure-profile-token-auto-sso), and then the profile being used set to the environment variable `AWS_DEFAULT_PROFILE`. If this is specified the uploader will attempt to authenticate using this profile which must have permission to access the specified S3 bucket. If using access keys, both the environment variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` must be set, and these will be used for authentication. If running via the provided Docker image these may be set using `--env` or `--env-file`.
+
+Only one authentication method may be used, if both `AWS_DEFAULT_PROFILE` and `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` are provided the uploader will exit and one method must be unset to continue.
+
+
 ## Logging
 
 All logs by default are written to `/var/log/s3_upload`. Logs from stdout and stderr are written to the file `s3_upload.log`, and are on a rotating time handle at midnight and backups stored in the same directory for 5 days.

--- a/s3_upload/utils/upload.py
+++ b/s3_upload/utils/upload.py
@@ -45,6 +45,15 @@ def check_aws_access():
     """
     log.info("Checking access to AWS")
 
+    if AWS_DEFAULT_PROFILE and (AWS_ACCESS_KEY or AWS_SECRET_KEY):
+        log.error(
+            "Both AWS_DEFAULT_PROFILE provided as well as AWS_ACCESS_KEY and /"
+            " or AWS_SECRET_KEY. Only one authentication method may be used."
+        )
+        sys.exit(
+            "Invalid environment variables for authentication method specified"
+        )
+
     if AWS_DEFAULT_PROFILE:
         log.info(
             "Environment variable AWS_DEFAULT_PROFILE defined, will be used"
@@ -55,12 +64,6 @@ def check_aws_access():
             "Environment variables AWS_ACCESS_KEY and AWS_SECRET_KEY defined,"
             " will be used for authentication"
         )
-    elif AWS_DEFAULT_PROFILE and (AWS_ACCESS_KEY or AWS_SECRET_KEY):
-        log.error(
-            "Both AWS_DEFAULT_PROFILE provided as well as AWS_ACCESS_KEY and /"
-            " or AWS_SECRET_KEY. Only one authentication method may be used."
-        )
-        sys.exit("Invalid authentication method specified")
     else:
         log.error(
             "Required environment variables for AWS authentication not defined"

--- a/s3_upload/utils/upload.py
+++ b/s3_upload/utils/upload.py
@@ -7,6 +7,7 @@ from concurrent.futures import (
 )
 from os import environ, path
 import re
+import sys
 from typing import Dict, List, Tuple
 
 import boto3
@@ -17,6 +18,8 @@ from botocore import exceptions as s3_exceptions
 from .log import get_logger
 
 AWS_DEFAULT_PROFILE = environ.get("AWS_DEFAULT_PROFILE")
+AWS_SECRET_KEY = environ.get("AWS_SECRET_KEY")
+AWS_ACCESS_KEY = environ.get("AWS_ACCESS_KEY")
 
 log = get_logger("s3_upload")
 
@@ -33,12 +36,47 @@ def check_aws_access():
 
     Raises
     ------
-    botocore.exceptions.ClientError
+    SystemExit
+        Raised when mutually exclusive AWS environment variables provided
+    SystemExit
+        Raised when required environment variables not defined
+    RuntimeError
         Raised when unable to connect to AWS
     """
     log.info("Checking access to AWS")
+
+    if AWS_DEFAULT_PROFILE:
+        log.info(
+            "Environment variable AWS_DEFAULT_PROFILE defined, will be used"
+            " for authentication"
+        )
+    elif AWS_ACCESS_KEY and AWS_SECRET_KEY:
+        log.info(
+            "Environment variables AWS_ACCESS_KEY and AWS_SECRET_KEY defined,"
+            " will be used for authentication"
+        )
+    elif AWS_DEFAULT_PROFILE and (AWS_ACCESS_KEY or AWS_SECRET_KEY):
+        log.error(
+            "Both AWS_DEFAULT_PROFILE provided as well as AWS_ACCESS_KEY and /"
+            " or AWS_SECRET_KEY. Only one authentication method may be used."
+        )
+        sys.exit("Invalid authentication method specified")
+    else:
+        log.error(
+            "Required environment variables for AWS authentication not defined"
+        )
+        sys.exit("AWS authentication credentials not provided")
+
     try:
-        return list(boto3.Session().resource("s3").buckets.all())
+        return list(
+            boto3.Session(
+                aws_access_key_id=AWS_ACCESS_KEY,
+                aws_secret_access_key=AWS_SECRET_KEY,
+                profile_name=AWS_DEFAULT_PROFILE,
+            )
+            .resource("s3")
+            .buckets.all()
+        )
     except s3_exceptions.ClientError as err:
         raise RuntimeError(f"Error in connecting to AWS: {err}") from err
 
@@ -71,7 +109,11 @@ def check_buckets_exist(buckets) -> List[dict]:
         try:
             log.debug("Checking %s exists and accessible", bucket)
             valid.append(
-                boto3.Session(profile_name=AWS_DEFAULT_PROFILE)
+                boto3.Session(
+                    aws_access_key_id=AWS_ACCESS_KEY,
+                    aws_secret_access_key=AWS_SECRET_KEY,
+                    profile_name=AWS_DEFAULT_PROFILE,
+                )
                 .client("s3")
                 .head_bucket(Bucket=bucket)
             )
@@ -222,7 +264,11 @@ def multi_thread_upload(
     """
     log.info("Uploading %s files with %s threads", len(files), threads)
 
-    session = boto3.session.Session(profile_name=AWS_DEFAULT_PROFILE)
+    session = boto3.session.Session(
+        aws_access_key_id=AWS_ACCESS_KEY,
+        aws_secret_access_key=AWS_SECRET_KEY,
+        profile_name=AWS_DEFAULT_PROFILE,
+    )
     s3_client = session.client(
         "s3",
         config=Config(

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -84,10 +84,13 @@ def get_peak_memory_usage() -> str:
     with open("benchmark.out", mode="r", encoding="utf8") as fh:
         contents = fh.read().splitlines()
 
+        # only keep the profile lines
+        contents = [x for x in contents if x.startswith("MEM")]
+
     os.remove("benchmark.out")
 
     try:
-        return round(max([float(x.split()[1]) for x in contents[1:]]), 2)
+        return round(max([float(x.split()[1]) for x in contents]), 2)
     except Exception as err:
         print(f"Error in parsing output from memory-profiler:\n{err}")
         print("Returning zero and continuing")

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -19,6 +19,8 @@ from typing import Tuple
 import boto3
 
 AWS_DEFAULT_PROFILE = os.environ.get("AWS_DEFAULT_PROFILE")
+AWS_SECRET_KEY = os.environ.get("AWS_SECRET_KEY")
+AWS_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY")
 
 
 def parse_args() -> argparse.Namespace:
@@ -111,7 +113,11 @@ def cleanup_remote_files(bucket, remote_path) -> None:
     """
     print(f"Deleting uploaded files from {bucket}:{remote_path}")
     bucket = (
-        boto3.Session(profile_name=AWS_DEFAULT_PROFILE)
+        boto3.Session(
+            aws_access_key_id=AWS_ACCESS_KEY,
+            aws_secret_access_key=AWS_SECRET_KEY,
+            profile_name=AWS_DEFAULT_PROFILE,
+        )
         .resource("s3")
         .Bucket(bucket)
     )

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -8,15 +8,29 @@ from pathlib import Path
 import sys
 import os
 
+import boto3
+
 sys.path.append(os.path.join(Path(__file__).parent.parent.parent, "s3_upload"))
 
+from s3_upload.utils.upload import check_aws_access
 
+AWS_DEFAULT_PROFILE = os.environ.get("AWS_DEFAULT_PROFILE")
+AWS_SECRET_KEY = os.environ.get("AWS_SECRET_KEY")
+AWS_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY")
 S3_BUCKET = os.environ.get("E2E_TEST_S3_BUCKET")
 
 if not S3_BUCKET:
     raise AttributeError(
         "Required E2E_TEST_S3_BUCKET not set as environment variable"
     )
+
+check_aws_access()
+
+S3_SESSION = boto3.Session(
+    aws_access_key_id=AWS_ACCESS_KEY,
+    aws_secret_access_key=AWS_SECRET_KEY,
+    profile_name=AWS_DEFAULT_PROFILE,
+)
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "test_data")
 

--- a/tests/e2e/helper.py
+++ b/tests/e2e/helper.py
@@ -10,7 +10,13 @@ import shutil
 
 import boto3
 
-from e2e import S3_BUCKET, TEST_DATA_DIR
+from e2e import (
+    AWS_ACCESS_KEY,
+    AWS_SECRET_KEY,
+    AWS_DEFAULT_PROFILE,
+    S3_BUCKET,
+    TEST_DATA_DIR,
+)
 
 
 def create_files(run_dir, *files):
@@ -64,7 +70,17 @@ def cleanup_remote_files(remote_path) -> None:
     remote_path : str
         path where files were uploaded to
     """
-    bucket = boto3.resource("s3").Bucket(S3_BUCKET)
+    print(f"Deleting uploaded files from {S3_BUCKET}:{remote_path}")
+    bucket = (
+        boto3.Session(
+            aws_access_key_id=AWS_ACCESS_KEY,
+            aws_secret_access_key=AWS_SECRET_KEY,
+            profile_name=AWS_DEFAULT_PROFILE,
+        )
+        .resource("s3")
+        .Bucket(S3_BUCKET)
+    )
+
     objects = bucket.objects.filter(Prefix=remote_path)
     objects = [{"Key": obj.key} for obj in objects]
 

--- a/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
+++ b/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
@@ -16,9 +16,7 @@ from unittest.mock import patch
 import os
 import shutil
 
-import boto3
-
-from e2e import BASE_CONFIG, S3_BUCKET, TEST_DATA_DIR
+from e2e import BASE_CONFIG, S3_BUCKET, S3_SESSION, TEST_DATA_DIR
 from e2e.helper import (
     cleanup_local_test_files,
     cleanup_remote_files,
@@ -129,7 +127,7 @@ class TestSingleCompleteRun(unittest.TestCase):
             [os.path.join(self.remote_path, "run_1", f) for f in local_files]
         )
 
-        bucket = boto3.resource("s3").Bucket(S3_BUCKET)
+        bucket = S3_SESSION.resource("s3").Bucket(S3_BUCKET)
         uploaded_objects = bucket.objects.filter(Prefix=self.remote_path)
         uploaded_files = sorted([x.key for x in uploaded_objects])
 

--- a/tests/e2e/test_regex_filtering_against_sample_names.py
+++ b/tests/e2e/test_regex_filtering_against_sample_names.py
@@ -20,9 +20,8 @@ from unittest.mock import patch
 import os
 import shutil
 
-import boto3
 
-from e2e import BASE_CONFIG, S3_BUCKET, TEST_DATA_DIR
+from e2e import BASE_CONFIG, S3_BUCKET, S3_SESSION, TEST_DATA_DIR
 from e2e.helper import (
     cleanup_local_test_files,
     cleanup_remote_files,
@@ -158,7 +157,7 @@ class TestConfigRegexPatternsAgainstSampleNames(unittest.TestCase):
             [os.path.join(self.parent_remote_path, f) for f in local_files]
         )
 
-        bucket = boto3.resource("s3").Bucket(S3_BUCKET)
+        bucket = S3_SESSION.resource("s3").Bucket(S3_BUCKET)
         uploaded_objects = bucket.objects.filter(
             Prefix=self.parent_remote_path
         )

--- a/tests/e2e/test_two_complete_runs_upload_to_two_remote_paths.py
+++ b/tests/e2e/test_two_complete_runs_upload_to_two_remote_paths.py
@@ -18,9 +18,7 @@ from unittest.mock import patch
 import os
 import shutil
 
-import boto3
-
-from e2e import BASE_CONFIG, S3_BUCKET, TEST_DATA_DIR
+from e2e import BASE_CONFIG, S3_BUCKET, S3_SESSION, TEST_DATA_DIR
 from e2e.helper import (
     cleanup_local_test_files,
     cleanup_remote_files,
@@ -141,7 +139,7 @@ class TestTwoCompleteRunsInSeparateMonitorDirectories(unittest.TestCase):
             [os.path.join(self.parent_remote_path, f) for f in local_files]
         )
 
-        bucket = boto3.resource("s3").Bucket(S3_BUCKET)
+        bucket = S3_SESSION.resource("s3").Bucket(S3_BUCKET)
         uploaded_objects = bucket.objects.filter(
             Prefix=self.parent_remote_path
         )

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -27,13 +27,11 @@ class TestGetConsoleHandler(unittest.TestCase):
 
 
 class TestSetFileHandler(unittest.TestCase):
-    # @classmethod
     def setUp(self):
         self.logger = log.get_logger("s3_upload", log_level=logging.INFO)
         log.set_file_handler(self.logger, Path(__file__).parent)
         self.logger.setLevel(5)
 
-    # @classmethod
     def tearDown(self):
         log_file = os.path.join(Path(__file__).parent, "s3_upload.log")
         if os.path.exists(log_file):
@@ -67,14 +65,8 @@ class TestSetFileHandler(unittest.TestCase):
         """
         self.logger.info("testing")
 
-        print(self.logger.handlers)
-        print(os.path.join(Path(__file__).parent, "s3_upload.log"))
-        # exit(1)
-
         with open(os.path.join(Path(__file__).parent, "s3_upload.log")) as fh:
             log_contents = fh.read()
-
-        print(log_contents)
 
         self.assertIn("INFO: testing", log_contents)
 
@@ -86,9 +78,6 @@ class TestSetFileHandler(unittest.TestCase):
             "INFO: Log file handler already set to"
             f" {os.path.join(Path(__file__).parent, 's3_upload.log')}"
         )
-
-        print(self.logger.handlers)
-        # exit(1)
 
         with open(os.path.join(Path(__file__).parent, "s3_upload.log")) as fh:
             log_contents = fh.read()

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -27,14 +27,14 @@ class TestGetConsoleHandler(unittest.TestCase):
 
 
 class TestSetFileHandler(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.logger = log.get_logger("s3_upload", log_level=logging.INFO)
-        log.set_file_handler(cls.logger, Path(__file__).parent)
-        cls.logger.setLevel(5)
+    # @classmethod
+    def setUp(self):
+        self.logger = log.get_logger("s3_upload", log_level=logging.INFO)
+        log.set_file_handler(self.logger, Path(__file__).parent)
+        self.logger.setLevel(5)
 
-    @classmethod
-    def tearDownClass(cls):
+    # @classmethod
+    def tearDown(self):
         log_file = os.path.join(Path(__file__).parent, "s3_upload.log")
         if os.path.exists(log_file):
             os.remove(log_file)

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -71,18 +71,14 @@ class TestSetFileHandler(unittest.TestCase):
         self.assertIn("INFO: testing", log_contents)
 
     def test_setting_file_twice_returns_the_handler(self):
-        log.set_file_handler(self.logger, Path(__file__).parent)
-        log.set_file_handler(self.logger, Path(__file__).parent)
 
-        expected_message = (
-            "INFO: Log file handler already set to"
-            f" {os.path.join(Path(__file__).parent, 's3_upload.log')}"
-        )
+        with patch(
+            "s3_upload.utils.log.check_write_permission_to_log_dir"
+        ) as mock_check:
+            # test we hit the early return and don't continue through the function
+            log.set_file_handler(self.logger, Path(__file__).parent)
 
-        with open(os.path.join(Path(__file__).parent, "s3_upload.log")) as fh:
-            log_contents = fh.read()
-
-        self.assertIn(expected_message, log_contents)
+            self.assertEqual(mock_check.call_count, 0)
 
 
 class TestCheckWritePermissionToLogDir(unittest.TestCase):

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -67,8 +67,14 @@ class TestSetFileHandler(unittest.TestCase):
         """
         self.logger.info("testing")
 
+        print(self.logger.handlers)
+        print(os.path.join(Path(__file__).parent, "s3_upload.log"))
+        # exit(1)
+
         with open(os.path.join(Path(__file__).parent, "s3_upload.log")) as fh:
             log_contents = fh.read()
+
+        print(log_contents)
 
         self.assertIn("INFO: testing", log_contents)
 

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -28,7 +28,9 @@ class TestGetConsoleHandler(unittest.TestCase):
 
 class TestSetFileHandler(unittest.TestCase):
     def setUp(self):
-        self.logger = log.get_logger("s3_upload", log_level=logging.INFO)
+        self.logger = log.get_logger(
+            f"s3_upload_{uuid4().hex}", log_level=logging.INFO
+        )
         log.set_file_handler(self.logger, Path(__file__).parent)
         self.logger.setLevel(5)
 

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -87,6 +87,9 @@ class TestSetFileHandler(unittest.TestCase):
             f" {os.path.join(Path(__file__).parent, 's3_upload.log')}"
         )
 
+        print(self.logger.handlers)
+        # exit(1)
+
         with open(os.path.join(Path(__file__).parent, "s3_upload.log")) as fh:
             log_contents = fh.read()
 

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -69,12 +69,12 @@ class TestCheckBucketsExist(unittest.TestCase):
     def test_bucket_metadata_returned_when_bucket_exists(self, mock_client):
         valid_bucket_metadata = {
             "ResponseMetadata": {
-                "RequestId": "8WQ3PBQNX",
-                "HostId": "1TvQsTG3ZQfoiuJrEFQBXBCMWFIX6DXA=",
+                "RequestId": "",
+                "HostId": "host_1",
                 "HTTPStatusCode": 200,
                 "HTTPHeaders": {
-                    "x-amz-id-2": "Hd4YGwX1TvQsTG3ZQfoiuJrEFQBXBCMWFIX6DXA=",
-                    "x-amz-request-id": "8WQ3PBQN3BX0G",
+                    "x-amz-id-2": "",
+                    "x-amz-request-id": "",
                     "date": "Fri, 04 Oct 2024 13:37:34 GMT",
                     "x-amz-bucket-region": "eu-west-2",
                     "x-amz-access-point-alias": "false",
@@ -180,7 +180,7 @@ class TestUploadSingleFile(unittest.TestCase):
 
     def test_local_file_name_and_object_id_returned(self, mock_client):
         mock_client.return_value.get_object.return_value = {
-            "ETag": "1TvQsTG3ZQfoiuJrEFQBXBCMWFIX6DXA"
+            "ETag": "remote_id"
         }
 
         local_file, remote_id = upload.upload_single_file(
@@ -195,7 +195,7 @@ class TestUploadSingleFile(unittest.TestCase):
             (local_file, remote_id),
             (
                 "/path/to/monitored_dir/run1/Samplesheet.csv",
-                "1TvQsTG3ZQfoiuJrEFQBXBCMWFIX6DXA",
+                "remote_id",
             ),
         )
 


### PR DESCRIPTION
- add ability to authenticate with AWS via access keys defined as environment variables 
  - ability to use SSO/IAM retained through use of `AWS_DEFAULT_PROFILE`
  - closes #11
- adjust tests for new changes
- add github action to add comment to new PRs with reminder to run e2e tests manually
- updated `.secrets.baseline` from removing random strings in `test_upload.py`
- update readme with new `Authentication` section

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/37)
<!-- Reviewable:end -->
