### PR TITLE
URA-872 - enable defining exclude_patterns from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Monitoring of specified directories for sequencing runs to upload are defined in
 * `bucket` (`str` | required): name of S3 bucket to upload to
 * `remote_path` (`str` | required): parent path in which to upload sequencing run directories in the specified bucket
 * `sample_regex` (`str` | optional): regex pattern to match against all samples parsed from the samplesheet, all samples must match this pattern to upload the run. This is to be used for controlling upload of specific runs where samplenames inform the assay / test.
+* `exclude_patterns` (`list` | optional): list of directory / filename regex patterns of which to exclude from uploading (e.g. [".*png"] would exclude the PNGs from Thumbnail_Images/ from being uploaded)
 
 Each dictionary inside of the list to monitor allows for setting separate upload locations for each of the monitored directories. For example, in the below codeblock the output of both `sequencer_1` and `sequencer_2` would be uploaded to the root of `bucket_A`, and the output of `sequencer_3` would be uploaded into `sequencer_3_runs` in `bucket_B`. Any number of these dictionaries may be defined in the monitor list.
 
@@ -76,7 +77,11 @@ Each dictionary inside of the list to monitor allows for setting separate upload
                 "/absolute/path/to/sequencer_3"
             ],
             "bucket": "bucket_B",
-            "remote_path": "/sequencer_3_runs"
+            "remote_path": "/sequencer_3_runs",
+            "exclude_patterns": [
+                "Config/",
+                ".*png"
+            ]
         }
     ]
 ```

--- a/example/example_config.json
+++ b/example/example_config.json
@@ -1,5 +1,5 @@
 {
-    "max_cores": 4,
+    "max_cores": 2,
     "max_threads": 8,
     "log_level": "INFO",
     "log_dir": "/var/log/s3_upload",

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -216,6 +216,9 @@ def monitor_directories_for_upload(config, dry_run):
                     "parent_path": Path(run_dir).parent,
                     "bucket": monitor_dir_config["bucket"],
                     "remote_path": monitor_dir_config["remote_path"],
+                    "exclude_patterns": monitor_dir_config.get(
+                        "exclude_patterns"
+                    ),
                 }
             )
 

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -278,7 +278,11 @@ def monitor_directories_for_upload(config, dry_run):
         # simple timer to log total upload time
         start = timer()
 
-        all_run_files = get_sequencing_file_list(run_config["run_dir"])
+        all_run_files = get_sequencing_file_list(
+            seq_dir=run_config["run_dir"],
+            exclude_patterns=run_config.get("exclude_patterns"),
+        )
+
         files_to_upload = all_run_files.copy()
 
         if run_config.get("uploaded_files"):

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -287,7 +287,13 @@ def get_sequencing_file_list(seq_dir, exclude_patterns=None) -> list:
         reverse=True,
     )
 
+    log.info("Found %s files in directory", len(files))
+
     if exclude_patterns:
+        log.info(
+            "Excluding files to upload against provided pattern(s): %s",
+            exclude_patterns,
+        )
         files = [
             x
             for x in files

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -287,7 +287,7 @@ def get_sequencing_file_list(seq_dir, exclude_patterns=None) -> list:
         reverse=True,
     )
 
-    log.info("Found %s files in directory", len(files))
+    log.info("Found %s files in %s", len(files), seq_dir)
 
     if exclude_patterns:
         log.info(

--- a/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
+++ b/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
@@ -3,8 +3,10 @@ End to end tests for running the upload in monitor mode.
 
 The below tests will fully simulate the upload process of a single
 sequencing run by setting up test run structure, calling the main entry
-point and testing the upload behaviour. This is the minimal end to end
-upload scenario to test.
+point and testing the upload behaviour. We will upload all files except
+the ThumbnailImage PNGs, which will be specified to exclude in the config.
+
+This is the minimal end to end upload scenario to test.
 """
 
 from argparse import Namespace
@@ -47,6 +49,9 @@ class TestSingleCompleteRun(unittest.TestCase):
             "CopyComplete.txt",
             "Config/Options.cfg",
             "InterOp/EventMetricsOut.bin",
+            "Recipe/HLJC5DRX5.xml"
+            "Thumbnail_Images/L001/C1.1/s_1_2103_green.png",
+            "Thumbnail_Images/L001/C1.1/s_1_2103_red.png",
         )
 
         shutil.copy(
@@ -58,7 +63,8 @@ class TestSingleCompleteRun(unittest.TestCase):
         now = datetime.now().strftime("%y%m%d_%H%M%S")
         cls.remote_path = f"s3_upload_e2e_test/{now}/sequencer_a"
 
-        # add in the sequencer to monitor with test run
+        # add in the sequencer to monitor with test run, excluding all
+        # files in the Recipe dir and all Thumbnail PNGs
         config_file = os.path.join(TEST_DATA_DIR, "test_config.json")
         config = deepcopy(BASE_CONFIG)
         config["log_dir"] = os.path.join(TEST_DATA_DIR, "logs")
@@ -69,6 +75,7 @@ class TestSingleCompleteRun(unittest.TestCase):
                 ],
                 "bucket": S3_BUCKET,
                 "remote_path": cls.remote_path,
+                "exclude_patterns": ["Recipe/", ".*png"],
             }
         )
 
@@ -114,7 +121,8 @@ class TestSingleCompleteRun(unittest.TestCase):
         """
         Test that the remote files are uploaded with the same directory
         structure as local and to the specified bucket:/path from the
-        config file
+        config file, and that we correctly exclude the specified files
+        from uploading as expected
         """
         local_files = [
             "RunInfo.xml",


### PR DESCRIPTION
- make use of optional config key "exclude_patterns" and pass through to `utils.get_sequencing_file_list`
- adjust `tests/e2e/test_one_complete_run_upload_to_one_remote_path.py` test case to use `exclude_patterns` from config
- add detail on exclude_pattern in readme
- closes #24 