### PR TITLE
URA-872 - add excluding of run upload by maximum allowable age

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,4 +20,18 @@ jobs:
       run: |
         sudo mkdir /var/log/s3_upload
         sudo chmod o+w /var/log/s3_upload
-        pytest -v --cov --count 10 --random-order tests/unit/
+        pytest -v --cov --cov-report xml --count 10 --random-order tests/unit/
+        total=$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")')
+        echo $total
+    - name: "Make badge"
+      uses: schneegans/dynamic-badges-action@v1.4.0
+      with:
+        # GIST_TOKEN is a GitHub personal access token with scope "gist".
+        auth: ${{ secrets.GIST_TOKEN }}
+        gistID: ${{ secrets.GIST_ID }}   # replace with your real Gist id.
+        filename: covbadge.json
+        label: Coverage
+        message: ${{ env.total }}%
+        minColorRange: 50
+        maxColorRange: 90
+        valColorRange: ${{ env.total }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,8 +23,8 @@ jobs:
         pytest -v --cov --count 10 --random-order tests/unit/
     - name: Get test coverage %
       run: |
-        pytest -v --cov --cov-report xml tests/unit/
-        export TOTAL=$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")')
+        pytest --cov --cov-report xml tests/unit/
+        export TOTAL=$(echo "$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")') * 100" | bc -l)
         echo "total=$TOTAL" >> $GITHUB_ENV
         echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
     - name: "Make badge"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Get test coverage %
       run: |
         pytest --cov --cov-report xml tests/unit/
-        export TOTAL=$(printf %.2f "$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")') * 100" | bc -l)
+        export TOTAL=$(printf %.2f $(echo "$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")') * 100" | bc -l))
         echo "total=$TOTAL" >> $GITHUB_ENV
         echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
     - name: "Make badge"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,12 +27,15 @@ jobs:
         export TOTAL=$(printf %.2f $(echo "$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")') * 100" | bc -l))
         echo "total=$TOTAL" >> $GITHUB_ENV
         echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
-    - name: "Make badge"
+    - name: Make coverage badge
       uses: schneegans/dynamic-badges-action@v1.4.0
       with:
-        # GIST_TOKEN is a GitHub personal access token with scope "gist".
+        # GIST_TOKEN is a GitHub personal access token with scope "gist"
+        # GIST_ID is the ID of the Gist where the covbadge.json is pushed to for the shields.io
+        # badge in the readme to use to display the coverage %, based off of:
+        # https://nedbatchelder.com/blog/202209/making_a_coverage_badge.html
         auth: ${{ secrets.GIST_TOKEN }}
-        gistID: ${{ secrets.GIST_ID }}   # replace with your real Gist id.
+        gistID: ${{ secrets.GIST_ID }}
         filename: covbadge.json
         label: Coverage
         message: ${{ env.total }}%

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,8 +20,12 @@ jobs:
       run: |
         sudo mkdir /var/log/s3_upload
         sudo chmod o+w /var/log/s3_upload
-        pytest -v --cov --cov-report xml --count 10 --random-order tests/unit/
+        pytest -v --cov --count 10 --random-order tests/unit/
+    - name: Get test coverage %
+        run: |
+        pytest -v --cov --cov-report xml tests/unit/
         total=$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")')
+        export $total
         echo $total
     - name: "Make badge"
       uses: schneegans/dynamic-badges-action@v1.4.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Get test coverage %
       run: |
         pytest --cov --cov-report xml tests/unit/
-        export TOTAL=$(echo "$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")') * 100" | bc -l)
+        export TOTAL=$(printf %.2f "$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")') * 100" | bc -l)
         echo "total=$TOTAL" >> $GITHUB_ENV
         echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
     - name: "Make badge"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Get test coverage %
       run: |
         pytest -v --cov --cov-report xml tests/unit/
-        total=$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")')
-        export $total
-        echo $total
+        export TOTAL=$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")')
+        echo "total=$TOTAL" >> $GITHUB_ENV
+        echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
     - name: "Make badge"
       uses: schneegans/dynamic-badges-action@v1.4.0
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
         sudo chmod o+w /var/log/s3_upload
         pytest -v --cov --count 10 --random-order tests/unit/
     - name: Get test coverage %
-        run: |
+      run: |
         pytest -v --cov --cov-report xml tests/unit/
         total=$(head -n2 coverage.xml | grep -Po '(?<=line-rate=\").*?(?=")')
         export $total

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The behaviour for monitoring of directories for sequencing runs to upload is con
 The top level keys that may be defined include:
 * `max_cores` (`int` | optional): maximum number of CPU cores to split uploading across (default: maximum available)
 * `max_threads` (`int` | optional): the maximum number of threads to use per CPU core
+* `max_age` (`int` | optional): maximum age of a complete run to monitor for upload, determined from mtime of `RunInfo.xml` (default: 72h)
 * `log_level` (`str` | optional): the level of logging to set, available options are defined [here](https://docs.python.org/3/library/logging.html#logging-levels)
 * `log_dir` (`str` | optional): path to where to store logs (default: `/var/log/s3_upload`)
 * `slack_log_webhook` (`str` | optional): Slack webhook URL to use for sending notifications on successful uploads, will try use `slack_alert_webhook` if not specified (see [Slack](https://github.com/eastgenomics/s3_upload?tab=readme-ov-file#slack) below for details).
@@ -185,6 +186,7 @@ Several [end to end test scenarios](https://github.com/eastgenomics/s3_upload/tr
 
 ## :pen: Notes
 * When running in monitor mode, a file lock is acquired on `s3_upload.lock`, which by default will be written into the log directory. This ensures only a single upload process may run at once, preventing duplicate concurrent uploads of the same files.
+* To prompt a run older than `max_age` as defined from the config file to be uploaded, the `mtime` of the `RunInfo.xml` can be updated with `touch /path/to/run_dir/RunInfo.xml`
 
 
 ## :hook: Pre-commit Hooks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AWS S3 upload
 
 ![pytest](https://github.com/eastgenomics/s3_upload/actions/workflows/pytest.yml/badge.svg)
+![coverage-badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jethror1/d591ef748f8a2c40c21ceedcad88a80e/raw/covbadge.json)
 
 Uploads Illumina sequencing runs into AWS S3 storage.
 

--- a/example/example_config.json
+++ b/example/example_config.json
@@ -1,6 +1,7 @@
 {
     "max_cores": 2,
     "max_threads": 8,
+    "max_age": 96,
     "log_level": "INFO",
     "log_dir": "/var/log/s3_upload",
     "slack_log_webhook": "https://hooks.slack.com/services/T0AG2K1C6/xxx",
@@ -13,7 +14,10 @@
             ],
             "bucket": "bucket_A",
             "remote_path": "/",
-            "sample_regex": "_assay_1_code_|_assay_code_2_"
+            "sample_regex": "_assay_1_code_|_assay_code_2_",
+            "exclude_patterns": [
+                "Thumbnail_Images/"
+            ]
         },
         {
             "monitored_directories": [

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -391,6 +391,13 @@ def main() -> None:
 
         log_dir = config.get("log_dir", "/var/log/s3_upload")
         lock_fd = acquire_lock(lock_file=path.join(log_dir, "s3_upload.lock"))
+
+        if config.get("log_level"):
+            log.setLevel(config.get("log_level"))
+
+        log.info("this is main info")
+        log.debug("this is main debug")
+
         set_file_handler(log, log_dir=log_dir)
 
         monitor_directories_for_upload(config=config, dry_run=args.dry_run)

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -221,6 +221,7 @@ def monitor_directories_for_upload(config, dry_run):
             monitor_dir_config.get("monitored_directories"),
             log_dir=log_dir,
             sample_pattern=monitor_dir_config.get("sample_regex"),
+            max_age=config.get("max_age", 72),
         )
 
         for run_dir in completed_runs:

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -386,13 +386,10 @@ def main() -> None:
         upload_single_run(args)
     else:
         config = read_config(config=args.config)
-
-        log_dir = config.get("log_dir", "/var/log/s3_upload")
-
-        lock_fd = acquire_lock(lock_file=path.join(log_dir, "s3_upload.lock"))
-
         verify_config(config=config)
 
+        log_dir = config.get("log_dir", "/var/log/s3_upload")
+        lock_fd = acquire_lock(lock_file=path.join(log_dir, "s3_upload.lock"))
         set_file_handler(log, log_dir=log_dir)
 
         monitor_directories_for_upload(config=config, dry_run=args.dry_run)

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -251,15 +251,6 @@ def get_runs_to_upload(
                 )
                 continue
 
-            if not check_run_age_within_limit(sub_dir):
-                log.debug(
-                    "%s older than maximum age (%s h) to monitor for upload "
-                    "and will not be uploaded",
-                    sub_dir,
-                    max_age,
-                )
-                continue
-
             samplesheet_contents = read_samplesheet_from_run_directory(sub_dir)
 
             if not samplesheet_contents:
@@ -295,6 +286,16 @@ def get_runs_to_upload(
                 )
                 partially_uploaded[sub_dir] = uploaded_files
             else:
+                # only try upload a newly picked up run if it's within age limit
+                if not check_run_age_within_limit(sub_dir):
+                    log.debug(
+                        "%s older than maximum age (%s h) to monitor for"
+                        " upload and will not be uploaded",
+                        sub_dir,
+                        max_age,
+                    )
+                    continue
+
                 log.info(
                     "%s has not started uploading, to be uploaded", sub_dir
                 )

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -192,7 +192,7 @@ def get_runs_to_upload(
     monitor_dirs,
     log_dir="/var/log/s3_upload",
     sample_pattern=None,
-    max_age=None,
+    max_age=72,
 ) -> Tuple[list, dict]:
     """
     Get completed sequencing runs to upload from specified directories
@@ -253,9 +253,10 @@ def get_runs_to_upload(
 
             if not check_run_age_within_limit(sub_dir):
                 log.debug(
-                    "%s older than maximum age to monitor for upload and will"
-                    " not be uploaded",
+                    "%s older than maximum age (%s h) to monitor for upload "
+                    "and will not be uploaded",
                     sub_dir,
+                    max_age,
                 )
                 continue
 

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -469,8 +469,22 @@ def verify_config(config) -> None:
     if not isinstance(config.get("max_threads", 0), int):
         errors.append("max_threads must be an integer")
 
-    if not config.get("log_dir"):
-        errors.append("required parameter log_dir not defined")
+    if config.get("log_level"):
+        level = config.get("log_level")
+        valid_str_levels = [
+            "NOTSET",
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL",
+        ]
+        valid_int_levels = [0, 10, 20, 30, 40, 50]
+
+        if (
+            isinstance(level, str) and level.upper() not in valid_str_levels
+        ) or (isinstance(level, int) and level not in valid_int_levels):
+            errors.append(f"Given log level is not valid: {level}")
 
     if not config.get("monitor"):
         errors.append("required parameter monitor not defined")

--- a/tests/unit/test_data/example_samplesheet.csv
+++ b/tests/unit/test_data/example_samplesheet.csv
@@ -1,0 +1,35 @@
+[Header]
+IEMFileVersion,4
+Investigator,scientist_1
+Experiment,my_experiment
+Date,Wed Oct 23 11:59:19 GMT 2024
+Workflow,GenerateFASTQ
+Application,NovaSeq FASTQ Only
+Assay,
+Description,assay_1
+Chemistry,Default
+
+[Reads]
+101
+101
+
+[Settings]
+AdapterRead1,CTGTCTCTTATACACATCTCCGAGCCCACGAGAC
+AdapterRead2,CTGTCTCTTATACACATCTGACGCTGCCGACGA
+AdapterBehavior,trim
+MinimumTrimmedReadLength,35
+MaskShortReads,35
+OverrideCycles,U7N1Y93;I10;I10;U7N1Y93
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,Index_ID,index,index2,Sample_Type,Pair_ID
+sample_1_assay_1,sample_1_assay_1,NV1079290-LIB,A1,UDP0001,GAACTGAGCG,CGCTCCACGA,DNA,sample_1_assay_1
+sample_2_assay_1,sample_2_assay_1,NV1079290-LIB,B1,UDP0002,AGGTCAGATA,TATCTTGTAG,DNA,sample_2_assay_1
+sample_3_assay_1,sample_3_assay_1,NV1079290-LIB,C1,UDP0003,CGTCTCATAT,AGCTACTATA,DNA,sample_3_assay_1
+sample_4_assay_1,sample_4_assay_1,NV1079290-LIB,D1,UDP0004,ATTCCATAAG,CCACCAGGCA,DNA,sample_4_assay_1
+sample_5_assay_1,sample_5_assay_1,NV1079290-LIB,E1,UDP0005,GACGAGATTA,AGGATAATGT,DNA,sample_5_assay_1
+sample_6_assay_1,sample_6_assay_1,NV1079290-LIB,F1,UDP0006,AACATCGCGC,ACAAGTGGAC,DNA,sample_6_assay_1
+sample_7_assay_1,sample_7_assay_1,NV1079290-LIB,G1,UDP0007,CTAGTGCTCT,TACTGTTCCA,DNA,sample_7_assay_1
+sample_8_assay_1,sample_8_assay_1,NV1079290-LIB,H1,UDP0008,GATCAAGGCA,ATTAACAAGG,DNA,sample_8_assay_1
+sample_9_assay_1,sample_9_assay_1,NV1079290-LIB,A2,UDP0009,GACTGAGTAG,CACTATCAAC,DNA,sample_9_assay_1
+sample_10_assay_1,sample_10_assay_1,NV1079290-LIB,B2,UDP0010,AGTCAGACGA,TGTCGCTGGT,DNA,sample_10_assay_1

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -94,6 +94,37 @@ class TestCheckIsSequencingRunDir(unittest.TestCase):
         os.remove(run_info_xml)
 
 
+class TestCheckRunAgeWithinLimit(unittest.TestCase):
+    def setUp(self):
+        self.test_run_dir = os.path.join(TEST_DATA_DIR, "test_run")
+        os.makedirs(
+            self.test_run_dir,
+            exist_ok=True,
+        )
+
+        open(os.path.join(self.test_run_dir, "RunInfo.xml"), mode="a").close()
+
+    def tearDown(self):
+        rmtree(self.test_run_dir)
+
+    def test_run_newer_than_specified_max_age_returns_true(self):
+        self.assertTrue(
+            utils.check_run_age_within_limit(self.test_run_dir, max_age=24)
+        )
+
+    def test_run_older_than_max_age_returns_false(self):
+        # update the modified time of RunInfo.xml to be older than the
+        # given max age (1621091308 => 16:08:28 - 15/5/2021)
+        os.utime(
+            path=os.path.join(self.test_run_dir, 'RunInfo.xml'),
+            times=(1621091308, 1621091308)
+        )
+
+        self.assertFalse(
+            utils.check_run_age_within_limit(self.test_run_dir, max_age=24)
+        )
+
+
 @patch("s3_upload.utils.utils.path.exists")
 @patch("s3_upload.utils.utils.read_upload_state_log")
 class TestCheckUploadState(unittest.TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import os
 import re
-from shutil import rmtree
+from shutil import copyfile, rmtree
 from uuid import uuid4
 import unittest
 from unittest.mock import patch
@@ -358,6 +358,10 @@ class TestGetRunsToUpload(unittest.TestCase):
         os.makedirs(old_run, exist_ok=True)
         open(os.path.join(old_run, "RunInfo.xml"), "w").close()
         open(os.path.join(old_run, "CopyComplete.txt"), "w").close()
+        copyfile(
+            os.path.join(TEST_DATA_DIR, "example_samplesheet.csv"),
+            os.path.join(old_run, "samplesheet.csv"),
+        )
 
         # update the modified time of RunInfo.xml to be older than the
         # given max age (1621091308 => 16:08:28 - 15/5/2021)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -921,7 +921,7 @@ class TestVerifyConfig(unittest.TestCase):
         valid_config = {
             "max_cores": 4,
             "max_threads": 8,
-            "log_level": "INFO",
+            "log_level": "DEBUG",
             "log_dir": "/var/log/s3_upload",
             "monitor": [
                 {
@@ -948,7 +948,7 @@ class TestVerifyConfig(unittest.TestCase):
         invalid_config = {
             "max_cores": "4",
             "max_threads": "8",
-            "log_level": "INFO",
+            "log_level": "BLARG",
             "monitor": [
                 {
                     "bucket": "bucket_A",
@@ -966,8 +966,8 @@ class TestVerifyConfig(unittest.TestCase):
 
         expected_errors = (
             "7 errors found in config:\n\tmax_cores must be an"
-            " integer\n\tmax_threads must be an integer\n\trequired parameter"
-            " log_dir not defined\n\trequired parameter monitored_directories"
+            " integer\n\tmax_threads must be an integer\n\tGiven log level is"
+            " not valid: BLARG\n\trequired parameter monitored_directories"
             " missing from monitor section 0\n\trequired parameter remote_path"
             " missing from monitor section 0\n\tbucket not of expected type"
             " from monitor section 1. Expected: <class 'str'> | Found <class"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -116,8 +116,8 @@ class TestCheckRunAgeWithinLimit(unittest.TestCase):
         # update the modified time of RunInfo.xml to be older than the
         # given max age (1621091308 => 16:08:28 - 15/5/2021)
         os.utime(
-            path=os.path.join(self.test_run_dir, 'RunInfo.xml'),
-            times=(1621091308, 1621091308)
+            path=os.path.join(self.test_run_dir, "RunInfo.xml"),
+            times=(1621091308, 1621091308),
         )
 
         self.assertFalse(
@@ -343,6 +343,49 @@ class TestGetRunsToUpload(unittest.TestCase):
                 )
 
                 self.assertTrue(expected_log_message in "".join(log.output))
+
+        rmtree(sequencer_output_dir)
+
+    def test_runs_over_max_age_skipped(self):
+        """
+        Runs to not monitor are determined from the max_age value stored
+        in the config, and mtime of the RunInfo.xml file
+        """
+        sequencer_output_dir = os.path.join(TEST_DATA_DIR, uuid4().hex)
+        old_run = os.path.join(
+            sequencer_output_dir, "16102023_A01295_001_ABC123"
+        )
+        os.makedirs(old_run, exist_ok=True)
+        open(os.path.join(old_run, "RunInfo.xml"), "w").close()
+        open(os.path.join(old_run, "CopyComplete.txt"), "w").close()
+
+        # update the modified time of RunInfo.xml to be older than the
+        # given max age (1621091308 => 16:08:28 - 15/5/2021)
+        os.utime(
+            path=os.path.join(old_run, "RunInfo.xml"),
+            times=(1621091308, 1621091308),
+        )
+
+        to_upload, partial_upload = utils.get_runs_to_upload(
+            monitor_dirs=[sequencer_output_dir], max_age=96
+        )
+
+        with self.subTest("testing outputs are empty"):
+            self.assertTrue(to_upload == [] and partial_upload == {})
+
+        with self.subTest("testing log message"):
+            pass
+        with self.assertLogs("s3_upload", level="DEBUG") as log:
+            utils.get_runs_to_upload(
+                monitor_dirs=[sequencer_output_dir], max_age=96
+            )
+
+            expected_log_message = (
+                f"{old_run} older than maximum age (96 h) to monitor "
+                "for upload and will not be uploaded"
+            )
+
+            self.assertIn(expected_log_message, "".join(log.output))
 
         rmtree(sequencer_output_dir)
 


### PR DESCRIPTION
- add `utils.check_run_age_within_limit()` to check for the age of a run being less than `max_age` hours defined in config file
  - closes #32
- remove `log_dir` from config validation (makes it actually optional as in docs)
- add in validation of `log_level` to config validation
- actually set `log_level` to logger if defined in config
- add unit tests to cover changes
- update GitHub actions to generate a new pretty % coverage badge for the readme
- update example config file
- running on server with `max_age` of 72h and `--dry_run` correctly identifies the following recent runs for upload:
```
2024-11-22 18:18:09,769 [s3_upload] INFO: Found 3 new sequencing runs to upload: 241120_A01295_0443_AHLJC2DRX5, 241121_A01295_0444_AHM3FCDRX5, 241121_A01303_0480_BHLYYCDRX5
2024-11-22 18:18:09,769 [s3_upload] INFO: /genetics/A01295a/241120_A01295_0443_AHLJC2DRX5 would be uploaded to jethro-s3-test-v2:/A01295/241120_A01295_0443_AHLJC2DRX5
2024-11-22 18:18:09,769 [s3_upload] INFO: /genetics/A01295a/241121_A01295_0444_AHM3FCDRX5 would be uploaded to jethro-s3-test-v2:/A01295/241121_A01295_0444_AHM3FCDRX5
2024-11-22 18:18:09,769 [s3_upload] INFO: /genetics/A01303b/241121_A01303_0480_BHLYYCDRX5 would be uploaded to jethro-s3-test-v2:/A01303/241121_A01303_0480_BHLYYCDRX5
```