### PR TITLE
URA-872 - ensure file lock always released

### DIFF
--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -1,4 +1,5 @@
 import argparse
+import atexit
 from os import cpu_count, makedirs, path
 from pathlib import Path
 import sys
@@ -7,7 +8,6 @@ from timeit import default_timer as timer
 from utils.io import (
     acquire_lock,
     read_config,
-    release_lock,
     write_upload_state_to_log,
 )
 from utils.upload import (
@@ -398,8 +398,6 @@ def main() -> None:
         set_file_handler(log, log_dir=log_dir)
 
         monitor_directories_for_upload(config=config, dry_run=args.dry_run)
-
-        release_lock(lock_fd)
 
 
 if __name__ == "__main__":

--- a/s3_upload/utils/io.py
+++ b/s3_upload/utils/io.py
@@ -1,4 +1,4 @@
-"General IO related methods"
+"""General IO related methods"""
 
 import atexit
 from datetime import datetime

--- a/s3_upload/utils/io.py
+++ b/s3_upload/utils/io.py
@@ -58,6 +58,8 @@ def acquire_lock(lock_file="/var/log/s3_upload/s3_upload.lock") -> int:
         # register the file lock to be released on exit
         atexit.register(release_lock, lock_fd=lock_fd)
 
+        return lock_fd
+
     except BlockingIOError:
         print(
             f"Could not acquire exclusive lock on {lock_file}, assuming"


### PR DESCRIPTION
- ensure the file lock is always released by registering it to be called on exit instead of directly calling `io.release_lock` in `main`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/46)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for directory monitoring and upload processes, providing detailed information about uploads.
	- Improved handling of the `dry_run` mode with appropriate logging messages.

- **Bug Fixes**
	- Adjusted resource management for locks to ensure proper cleanup upon program termination.

- **Documentation**
	- Updated docstring format in the `io.py` module for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->