### PR TITLE
URA-872 - raise FileNotFoundError on provided directory to upload not existing

### DIFF
--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -327,8 +327,19 @@ def get_sequencing_file_list(seq_dir, exclude_patterns=None) -> list:
     -------
     list
         sorted list of files by their file size (descending)
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if the provided directory does not exist / not accessible
     """
     log.info("Getting list of files to upload in %s", seq_dir)
+
+    if not Path(seq_dir).absolute().exists():
+        raise FileNotFoundError(
+            f"Provided directory does not exist: {seq_dir}"
+        )
+
     files = sorted(
         [
             (x, stat(x).st_size)

--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -336,6 +336,7 @@ def get_sequencing_file_list(seq_dir, exclude_patterns=None) -> list:
     log.info("Getting list of files to upload in %s", seq_dir)
 
     if not Path(seq_dir).absolute().exists():
+        log.error("Provided directory does not exist: %s", seq_dir)
         raise FileNotFoundError(
             f"Provided directory does not exist: {seq_dir}"
         )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -806,9 +806,7 @@ class TestGetSequencingFileList(unittest.TestCase):
         invalid_dir = os.path.join(TEST_DATA_DIR, uuid4().hex)
         expected_error = f"Provided directory does not exist: {invalid_dir}"
 
-        with pytest.raises(
-            FileNotFoundError, match=re.escape(expected_error)
-        ):
+        with pytest.raises(FileNotFoundError, match=re.escape(expected_error)):
             utils.get_sequencing_file_list(seq_dir=invalid_dir)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -806,8 +806,8 @@ class TestGetSequencingFileList(unittest.TestCase):
         invalid_dir = os.path.join(TEST_DATA_DIR, uuid4().hex)
         expected_error = f"Provided directory does not exist: {invalid_dir}"
 
-        with self.assertRaises(
-            FileNotFoundError, matches=re.escape(expected_error)
+        with pytest.raises(
+            FileNotFoundError, match=re.escape(expected_error)
         ):
             utils.get_sequencing_file_list(seq_dir=invalid_dir)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -802,6 +802,15 @@ class TestGetSequencingFileList(unittest.TestCase):
                     sorted(returned_file_list), sorted(expected_files)
                 )
 
+    def test_file_not_found_error_raised_on_invalid_directory_provided(self):
+        invalid_dir = os.path.join(TEST_DATA_DIR, uuid4().hex)
+        expected_error = f"Provided directory does not exist: {invalid_dir}"
+
+        with self.assertRaises(
+            FileNotFoundError, matches=re.escape(expected_error)
+        ):
+            utils.get_sequencing_file_list(seq_dir=invalid_dir)
+
 
 class TestGetSamplenamesFromSamplesheet(unittest.TestCase):
     samplesheet_contents = [


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/47)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for directory access in the file listing function, providing clearer feedback when a directory is not found.

- **Bug Fixes**
	- Introduced a test to ensure that a `FileNotFoundError` is raised when an invalid directory is specified, improving reliability.

- **Documentation**
	- Updated docstring for the file listing function to include details about the new exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->