### PR TITLE
URA-872 - fix to ensure max_age used for monitoring

### DIFF
--- a/s3_upload/utils/utils.py
+++ b/s3_upload/utils/utils.py
@@ -290,7 +290,9 @@ def get_runs_to_upload(
                 partially_uploaded[sub_dir] = uploaded_files
             else:
                 # only try upload a newly picked up run if it's within age limit
-                if not check_run_age_within_limit(sub_dir):
+                if not check_run_age_within_limit(
+                    run_dir=sub_dir, max_age=max_age
+                ):
                     log.debug(
                         "%s older than maximum age (%s h) to monitor for"
                         " upload and will not be uploaded",


### PR DESCRIPTION
- fixes bug in not passing through `max_age` from config to `check_run`_age_within_limit` from `get_runs_to_upload`
- adjust unit tests to ensure behaviour fixed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/48)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the logic for checking run age limits during uploads, ensuring accurate handling of runs based on their age.

- **Tests**
	- Improved the test suite for run age checks, including more detailed assertions and logging to verify correct behaviour for runs within and exceeding the maximum age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->