### PR TITLE
URA-872 - fixes for logging and Slack alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Only one authentication method may be used, if both `AWS_DEFAULT_PROFILE` and `A
 
 ## :wood: Logging
 
-All logs by default are written to `/var/log/s3_upload`. Logs from stdout and stderr are written to the file `s3_upload.log.{YY-MM-DD}`, with all logs from an invocation of the upload being written to that days log (i.e if the upload begins at 11.59pm, all logs from that upload would be written to that days file and not roll over to the next). Backups are rotated and stored in the same directory for 5 days.
+All logs by default are written to `/var/log/s3_upload`. Logs from stdout and stderr are written to the file `s3_upload.log.{YYYY-MM-DD}`, with all logs from an invocation of the upload being written to that days log (i.e if the upload begins at 11.59pm, all logs from that upload would be written to that days file and not roll over to the next). Backups are rotated and stored in the same directory for 5 days.
 
 > [!IMPORTANT]
 > Write permission is required to the default or specified log directory, if not a `PermissionError` will be raised on checking the log directory permissions.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Only one authentication method may be used, if both `AWS_DEFAULT_PROFILE` and `A
 
 ## :wood: Logging
 
-All logs by default are written to `/var/log/s3_upload`. Logs from stdout and stderr are written to the file `s3_upload.log.{YYYY-MM-DD}`, with all logs from an invocation of the upload being written to that days log (i.e if the upload begins at 11.59pm, all logs from that upload would be written to that days file and not roll over to the next). Backups are rotated and stored in the same directory for 5 days.
+All logs by default are written to `/var/log/s3_upload`. Logs from stdout and stderr are written to the file `s3_upload.log.{YYYY-MM-DD}`, with all logs from an invocation of the upload being written to that day's log (i.e if the upload begins at 11.59pm, all logs from that upload would be written to that day's file and not roll over to the next). Backups are rotated and stored in the same directory for 5 days.
 
 > [!IMPORTANT]
 > Write permission is required to the default or specified log directory, if not a `PermissionError` will be raised on checking the log directory permissions.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Only one authentication method may be used, if both `AWS_DEFAULT_PROFILE` and `A
 
 ## :wood: Logging
 
-All logs by default are written to `/var/log/s3_upload`. Logs from stdout and stderr are written to the file `s3_upload.log`, and are on a rotating time handle at midnight and backups stored in the same directory for 5 days.
+All logs by default are written to `/var/log/s3_upload`. Logs from stdout and stderr are written to the file `s3_upload.log.{YY-MM-DD}`, with all logs from an invocation of the upload being written to that days log (i.e if the upload begins at 11.59pm, all logs from that upload would be written to that days file and not roll over to the next). Backups are rotated and stored in the same directory for 5 days.
 
 > [!IMPORTANT]
 > Write permission is required to the default or specified log directory, if not a `PermissionError` will be raised on checking the log directory permissions.

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -389,7 +389,7 @@ def main() -> None:
         verify_config(config=config)
 
         log_dir = config.get("log_dir", "/var/log/s3_upload")
-        lock_fd = acquire_lock(lock_file=path.join(log_dir, "s3_upload.lock"))
+        acquire_lock(lock_file=path.join(log_dir, "s3_upload.lock"))
 
         if config.get("log_level"):
             log.setLevel(config.get("log_level"))

--- a/s3_upload/s3_upload.py
+++ b/s3_upload/s3_upload.py
@@ -1,5 +1,4 @@
 import argparse
-import atexit
 from os import cpu_count, makedirs, path
 from pathlib import Path
 import sys

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -41,17 +41,18 @@ def set_file_handler(logger, log_dir) -> logging.Logger:
     """
     check_write_permission_to_log_dir(log_dir)
 
+    log_file = os.path.join(
+        log_dir, f"s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}"
+    )
+
     existing_file_handler = [
         x for x in logger.handlers if isinstance(x, FileHandler)
     ]
 
-    if existing_file_handler:
+    if existing_file_handler and os.path.exists(log_file):
         logger.debug("FileHandler already set")
         return logger
 
-    log_file = os.path.join(
-        log_dir, f"s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}"
-    )
     Path(log_dir).mkdir(parents=True, exist_ok=True)
     Path(log_file).touch(exist_ok=True)
 

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -41,6 +41,14 @@ def set_file_handler(logger, log_dir) -> logging.Logger:
     """
     check_write_permission_to_log_dir(log_dir)
 
+    existing_file_handler = [
+        x for x in logger.handlers if isinstance(x, FileHandler)
+    ]
+
+    if existing_file_handler:
+        logger.debug("FileHandler already set")
+        return logger
+
     log_file = os.path.join(
         log_dir, f"s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}"
     )
@@ -53,7 +61,7 @@ def set_file_handler(logger, log_dir) -> logging.Logger:
     logger.addHandler(file_handler)
 
     logger.info(
-        "Initialised log fileHandler, setting log output to %s", log_file
+        "Initialised log FileHandler, setting log output to %s", log_file
     )
 
     clear_old_logs(logger=logger, log_dir=log_dir, backup_count=5)

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -110,10 +110,8 @@ def clear_old_logs(logger, log_dir, backup_count) -> None:
         for old_file in old_backup_files:
             try:
                 os.remove(old_file)
-            except OSError as error:
-                logger.exception(
-                    "Failed to delete old log file %s: %s", old_file, error
-                )
+            except OSError:
+                logger.exception("Failed to delete old log file %s", old_file)
 
 
 def check_write_permission_to_log_dir(log_dir) -> None:

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -111,7 +111,7 @@ def clear_old_logs(logger, log_dir, backup_count) -> None:
             try:
                 os.remove(old_file)
             except OSError as error:
-                logger.error(
+                logger.exception(
                     "Failed to delete old log file %s: %s", old_file, error
                 )
 

--- a/s3_upload/utils/log.py
+++ b/s3_upload/utils/log.py
@@ -1,9 +1,12 @@
 """Functions to handle log streams"""
 
+from datetime import date, datetime, time, timedelta
+from glob import glob
 import logging
-from logging.handlers import TimedRotatingFileHandler
+from logging import FileHandler
 import os
 from pathlib import Path
+import re
 import sys
 
 
@@ -20,7 +23,8 @@ def get_console_handler() -> logging.StreamHandler:
 
 def set_file_handler(logger, log_dir) -> logging.Logger:
     """
-    Set the file handler to redirect all logs to log file `s3_upload.log`
+    Set the file handler to redirect all logs to log file
+    `s3_upload.log.{%Y-%m-%d}`
     in the specified directory
 
     Parameters
@@ -35,29 +39,72 @@ def set_file_handler(logger, log_dir) -> logging.Logger:
     logging.Logger
         logging handler
     """
-    log_file = os.path.join(log_dir, "s3_upload.log")
+    check_write_permission_to_log_dir(log_dir)
 
-    if any(
-        [isinstance(x, TimedRotatingFileHandler) for x in logger.handlers]
-    ) and os.path.exists(log_file):
-        # log file handler already set and log file exists => use it
-        logger.info("Log file handler already set to %s", log_file)
-        return logger
+    log_file = os.path.join(
+        log_dir, f"s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}"
+    )
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
+    Path(log_file).touch(exist_ok=True)
+
+    file_handler = FileHandler(filename=log_file)
+    file_handler.setFormatter(FORMATTER)
+
+    logger.addHandler(file_handler)
 
     logger.info(
         "Initialised log fileHandler, setting log output to %s", log_file
     )
 
-    check_write_permission_to_log_dir(log_dir)
-
-    file_handler = TimedRotatingFileHandler(
-        log_file, when="midnight", backupCount=5
-    )
-    file_handler.setFormatter(FORMATTER)
-
-    logger.addHandler(file_handler)
+    clear_old_logs(logger=logger, log_dir=log_dir, backup_count=5)
 
     return logger
+
+
+def clear_old_logs(logger, log_dir, backup_count) -> None:
+    """
+    Ensures that at most `backup_count` log file backups are retained.
+
+    To be called on initialising the log file handler which sets the log
+    output to a file with the current datetime stamp as suffix, this will
+    be used to delete files older than `backup_count` days.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        handle to the logger
+    log_dir : str
+        path to log directory
+    backup_count : int
+    """
+    oldest_backup_date = datetime.combine(
+        (date.today() - timedelta(days=backup_count)), time()
+    )
+
+    backup_files = [
+        (f, re.search(r"\d{4}-\d{2}-\d{2}$|$", f).group())
+        for f in glob(f"{log_dir}/s3_upload.log.*")
+    ]
+    old_backup_files = [
+        x[0]
+        for x in backup_files
+        if x[1] and datetime.strptime(x[1], "%Y-%m-%d") < oldest_backup_date
+    ]
+
+    logger.debug(
+        "%s old backup files to be removed: %s",
+        len(old_backup_files),
+        old_backup_files,
+    )
+
+    if old_backup_files:
+        for old_file in old_backup_files:
+            try:
+                os.remove(old_file)
+            except OSError as error:
+                logger.error(
+                    "Failed to delete old log file %s: %s", old_file, error
+                )
 
 
 def check_write_permission_to_log_dir(log_dir) -> None:
@@ -112,12 +159,6 @@ def get_logger(
     if logging.getLogger(logger_name).handlers:
         # logger already exists => use it
         return logging.getLogger(logger_name)
-
-    log_file = os.path.join(log_dir, "s3_upload.log")
-    check_write_permission_to_log_dir(log_dir)
-
-    Path(log_dir).mkdir(parents=True, exist_ok=True)
-    Path(log_file).touch(exist_ok=True)
 
     logger = logging.getLogger(logger_name)
 

--- a/s3_upload/utils/slack.py
+++ b/s3_upload/utils/slack.py
@@ -28,16 +28,19 @@ def format_message(completed=None, failed=None) -> str:
     message = ""
 
     if completed:
+        suffix = "" if len(completed) == 1 else "s"
         message += ":white_check_mark:  *S3 Upload*: Successfully uploaded "
-        message += f"{len(completed)} runs\n\t\t• "
+        message += f"{len(completed)} run{suffix}\n\t\t• "
         message += "\n\t\t• ".join(completed)
 
     if failed:
+        suffix = "" if len(failed) == 1 else "s"
         if message:
             message += "\n\n"
 
         message += (
-            f":x:  *S3 Upload*: Failed uploading {len(failed)} runs\n\t\t• "
+            ":x:  *S3 Upload*: Failed uploading"
+            f" {len(failed)} run{suffix}\n\t\t• "
         )
         message += "\n\t\t• ".join(failed)
 

--- a/s3_upload/utils/slack.py
+++ b/s3_upload/utils/slack.py
@@ -29,17 +29,17 @@ def format_message(completed=None, failed=None) -> str:
 
     if completed:
         message += ":white_check_mark:  *S3 Upload*: Successfully uploaded "
-        message += f"{len(completed)} runs\n\t• "
-        message += "\n\t• ".join(completed)
+        message += f"{len(completed)} runs\n\t\t• "
+        message += "\n\t\t• ".join(completed)
 
     if failed:
         if message:
             message += "\n\n"
 
         message += (
-            f":x:  *S3 Upload*: Failed uploading {len(failed)} runs\n\t• "
+            f":x:  *S3 Upload*: Failed uploading {len(failed)} runs\n\t\t• "
         )
-        message += "\n\t• ".join(failed)
+        message += "\n\t\t• ".join(failed)
 
     return message
 

--- a/s3_upload/utils/slack.py
+++ b/s3_upload/utils/slack.py
@@ -29,18 +29,17 @@ def format_message(completed=None, failed=None) -> str:
 
     if completed:
         message += ":white_check_mark:  *S3 Upload*: Successfully uploaded "
-        message += f"{len(completed)} runs\n\t:black_square: "
-        message += "\n\t:black_square: ".join(completed)
+        message += f"{len(completed)} runs\n\t• "
+        message += "\n\t• ".join(completed)
 
     if failed:
         if message:
             message += "\n\n"
 
         message += (
-            ":x:  *S3 Upload*: Failed uploading"
-            f" {len(failed)} runs\n\t:black_square: "
+            f":x:  *S3 Upload*: Failed uploading {len(failed)} runs\n\t• "
         )
-        message += "\n\t:black_square: ".join(failed)
+        message += "\n\t• ".join(failed)
 
     return message
 

--- a/tests/e2e/helper.py
+++ b/tests/e2e/helper.py
@@ -2,6 +2,7 @@
 Simple helper functions used in most tests for set up and clean up
 """
 
+from datetime import datetime
 from glob import glob
 import json
 from os import makedirs, path, remove
@@ -115,7 +116,10 @@ def read_stdout_stderr_log() -> list:
         contents of log file
     """
     with open(
-        path.join(TEST_DATA_DIR, "logs/s3_upload.log"),
+        path.join(
+            TEST_DATA_DIR,
+            f"logs/s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}",
+        ),
         encoding="utf8",
         mode="r",
     ) as fh:

--- a/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
+++ b/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
@@ -27,6 +27,8 @@ from e2e.helper import (
 
 from s3_upload.s3_upload import main as s3_upload_main
 
+TODAY = datetime.now().strftime("%Y-%m-%d")
+
 
 class TestSingleCompleteRun(unittest.TestCase):
     """
@@ -103,7 +105,7 @@ class TestSingleCompleteRun(unittest.TestCase):
 
         # capture the stdout/stderr logs written to log file for testing
         with open(
-            os.path.join(TEST_DATA_DIR, "logs/s3_upload.log"), "r"
+            os.path.join(TEST_DATA_DIR, f"logs/s3_upload.log.{TODAY}"), "r"
         ) as fh:
             cls.upload_log = fh.read().splitlines()
 
@@ -224,7 +226,7 @@ class TestSingleCompleteRun(unittest.TestCase):
         with self.subTest("message formatted as expected"):
             expected_message = (
                 ":white_check_mark:  *S3 Upload*: Successfully uploaded 1"
-                " runs\n\t:black_square: run_1"
+                " run\n\t\t• run_1"
             )
 
             self.assertEqual(

--- a/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
+++ b/tests/e2e/test_one_complete_run_upload_to_one_remote_path.py
@@ -23,11 +23,10 @@ from e2e.helper import (
     cleanup_local_test_files,
     cleanup_remote_files,
     create_files,
+    read_stdout_stderr_log,
 )
 
 from s3_upload.s3_upload import main as s3_upload_main
-
-TODAY = datetime.now().strftime("%Y-%m-%d")
 
 
 class TestSingleCompleteRun(unittest.TestCase):
@@ -104,10 +103,7 @@ class TestSingleCompleteRun(unittest.TestCase):
         s3_upload_main()
 
         # capture the stdout/stderr logs written to log file for testing
-        with open(
-            os.path.join(TEST_DATA_DIR, f"logs/s3_upload.log.{TODAY}"), "r"
-        ) as fh:
-            cls.upload_log = fh.read().splitlines()
+        cls.upload_log = read_stdout_stderr_log()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/e2e/test_regex_filtering_against_sample_names.py
+++ b/tests/e2e/test_regex_filtering_against_sample_names.py
@@ -26,6 +26,7 @@ from e2e.helper import (
     cleanup_local_test_files,
     cleanup_remote_files,
     create_files,
+    read_stdout_stderr_log,
 )
 from s3_upload.s3_upload import main as s3_upload_main
 
@@ -120,10 +121,7 @@ class TestConfigRegexPatternsAgainstSampleNames(unittest.TestCase):
         s3_upload_main()
 
         # capture the stdout/stderr logs written to log file for testing
-        with open(
-            os.path.join(TEST_DATA_DIR, "logs/s3_upload.log"), "r"
-        ) as fh:
-            cls.upload_log = fh.read().splitlines()
+        cls.upload_log = read_stdout_stderr_log()
 
     @classmethod
     def tearDownClass(cls):
@@ -275,7 +273,7 @@ class TestConfigRegexPatternsAgainstSampleNames(unittest.TestCase):
         with self.subTest("message formatted as expected"):
             expected_message = (
                 ":white_check_mark:  *S3 Upload*: Successfully uploaded 2"
-                " runs\n\t:black_square: run_1\n\t:black_square: run_2"
+                " runs\n\t\t• run_1\n\t\t• run_2"
             )
 
             self.assertEqual(

--- a/tests/e2e/test_resuming_partially_uploaded_runs.py
+++ b/tests/e2e/test_resuming_partially_uploaded_runs.py
@@ -244,8 +244,7 @@ class TestInterruptAndResume(unittest.TestCase):
             expected_call_args = {
                 "url": "https://slack_webhook_alert_channel",
                 "message": (
-                    ":x:  *S3 Upload*: Failed uploading 1"
-                    " runs\n\t:black_square: run_1"
+                    ":x:  *S3 Upload*: Failed uploading 1 run\n\t\t• run_1"
                 ),
             }
             self.assertEqual(
@@ -257,7 +256,7 @@ class TestInterruptAndResume(unittest.TestCase):
                 "url": "https://slack_webhook_log_channel",
                 "message": (
                     ":white_check_mark:  *S3 Upload*: Successfully uploaded 1"
-                    " runs\n\t:black_square: run_1"
+                    " run\n\t\t• run_1"
                 ),
             }
 

--- a/tests/e2e/test_two_complete_runs_upload_to_two_remote_paths.py
+++ b/tests/e2e/test_two_complete_runs_upload_to_two_remote_paths.py
@@ -23,6 +23,7 @@ from e2e.helper import (
     cleanup_local_test_files,
     cleanup_remote_files,
     create_files,
+    read_stdout_stderr_log,
 )
 from s3_upload.s3_upload import main as s3_upload_main
 
@@ -103,10 +104,7 @@ class TestTwoCompleteRunsInSeparateMonitorDirectories(unittest.TestCase):
         s3_upload_main()
 
         # capture the stdout/stderr logs written to log file for testing
-        with open(
-            os.path.join(TEST_DATA_DIR, "logs/s3_upload.log"), "r"
-        ) as fh:
-            cls.upload_log = fh.read().splitlines()
+        cls.upload_log = read_stdout_stderr_log()
 
     @classmethod
     def tearDownClass(cls):
@@ -244,7 +242,7 @@ class TestTwoCompleteRunsInSeparateMonitorDirectories(unittest.TestCase):
         with self.subTest("message formatted as expected"):
             expected_message = (
                 ":white_check_mark:  *S3 Upload*: Successfully uploaded 2"
-                " runs\n\t:black_square: run_1\n\t:black_square: run_2"
+                " runs\n\t\t• run_1\n\t\t• run_2"
             )
 
             self.assertEqual(

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -157,10 +157,7 @@ class TestClearOldLogs(unittest.TestCase):
                 logger=self.logger, log_dir=TEST_DATA_DIR, backup_count=-1
             )
 
-            expected_log_error = (
-                f"Failed to delete old log file {today_log}: file can not be"
-                " deleted"
-            )
+            expected_log_error = f"Failed to delete old log file {today_log}"
 
             self.assertIn(expected_log_error, "".join(log_output.output))
 

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime, time, timedelta
 import logging
 from logging import FileHandler
 import os
@@ -32,15 +32,18 @@ class TestSetFileHandler(unittest.TestCase):
         self.logger = log.get_logger(
             f"s3_upload_{uuid4().hex}", log_level=logging.INFO
         )
-        self.log_file = f"s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}"
+        self.log_file = os.path.join(
+            TEST_DATA_DIR,
+            f"s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}",
+        )
 
-        log.set_file_handler(self.logger, Path(__file__).parent)
+        log.set_file_handler(self.logger, TEST_DATA_DIR)
         self.logger.setLevel(5)
 
     def tearDown(self):
-        log_file = os.path.join(Path(__file__).parent, "s3_upload.log")
-        if os.path.exists(log_file):
-            os.remove(log_file)
+        log.clear_old_logs(
+            logger=self.logger, log_dir=TEST_DATA_DIR, backup_count=-1
+        )
 
     def test_file_handler_correctly_set(self):
 
@@ -64,7 +67,7 @@ class TestSetFileHandler(unittest.TestCase):
         """
         self.logger.info("testing")
 
-        with open(os.path.join(Path(__file__).parent, self.log_file)) as fh:
+        with open(self.log_file) as fh:
             log_contents = fh.read()
 
         self.assertIn("INFO: testing", log_contents)
@@ -75,9 +78,91 @@ class TestSetFileHandler(unittest.TestCase):
             "s3_upload.utils.log.logging.Handler.setFormatter"
         ) as mock_file_handler:
             # test we hit the early return and don't continue through the function
-            log.set_file_handler(self.logger, Path(__file__).parent)
+            log.set_file_handler(self.logger, TEST_DATA_DIR)
 
             self.assertEqual(mock_file_handler.call_count, 0)
+
+
+class TestClearOldLogs(unittest.TestCase):
+    def setUp(self):
+        self.logger = log.get_logger(
+            f"s3_upload_{uuid4().hex}", log_level=logging.INFO
+        )
+
+    def tearDown(self):
+        log.clear_old_logs(
+            logger=self.logger, log_dir=TEST_DATA_DIR, backup_count=-1
+        )
+
+    def test_files_older_than_backup_count_are_deleted(self):
+        """
+        Log files older than specified `backup_count` days are determined
+        from the YY-MM-DD suffix on the file name and should be removed
+        """
+        five_days_ago = datetime.combine(
+            (date.today() - timedelta(days=5)), time()
+        ).strftime("%Y-%m-%d")
+        six_days_ago = datetime.combine(
+            (date.today() - timedelta(days=6)), time()
+        ).strftime("%Y-%m-%d")
+
+        open(
+            Path(TEST_DATA_DIR).joinpath(f"s3_upload.log.{five_days_ago}"),
+            encoding="utf-8",
+            mode="a",
+        ).close()
+        open(
+            Path(TEST_DATA_DIR).joinpath(f"s3_upload.log.{six_days_ago}"),
+            encoding="utf-8",
+            mode="a",
+        ).close()
+
+        log.clear_old_logs(
+            logger=self.logger, log_dir=TEST_DATA_DIR, backup_count=5
+        )
+
+        with self.subTest("newer log file retained"):
+            self.assertTrue(
+                os.path.exists(
+                    Path(TEST_DATA_DIR).joinpath(
+                        f"s3_upload.log.{five_days_ago}"
+                    )
+                )
+            )
+
+        with self.subTest("older log file deleted"):
+            self.assertFalse(
+                os.path.exists(
+                    Path(TEST_DATA_DIR).joinpath(
+                        f"s3_upload.log.{six_days_ago}"
+                    )
+                )
+            )
+
+    @patch("s3_upload.utils.log.os.remove")
+    def test_errors_on_deleting_caught_and_logged_but_not_raised(
+        self, mock_remove
+    ):
+        # create a log file
+        log.set_file_handler(logger=self.logger, log_dir=TEST_DATA_DIR)
+
+        today_log = Path(TEST_DATA_DIR).joinpath(
+            f"s3_upload.log.{datetime.now().strftime('%Y-%m-%d')}"
+        )
+
+        mock_remove.side_effect = OSError("file can not be deleted")
+
+        with self.assertLogs(self.logger) as log_output:
+            log.clear_old_logs(
+                logger=self.logger, log_dir=TEST_DATA_DIR, backup_count=-1
+            )
+
+            expected_log_error = (
+                f"Failed to delete old log file {today_log}: file can not be"
+                " deleted"
+            )
+
+            self.assertIn(expected_log_error, "".join(log_output.output))
 
 
 class TestCheckWritePermissionToLogDir(unittest.TestCase):

--- a/tests/unit/test_slack.py
+++ b/tests/unit/test_slack.py
@@ -6,6 +6,23 @@ from s3_upload.utils import slack
 
 
 class TestFormatCompleteMessage(unittest.TestCase):
+    def test_suffix_set_correctly_for_one_run(self):
+        """
+        Test that when there is only one completed / failed upload that we
+        drop the `s` from runs for correct Englishness
+        """
+        compiled_message = slack.format_message(
+            completed=["run_1"], failed=["run_2"]
+        )
+
+        expected_message = (
+            ":white_check_mark:  *S3 Upload*: Successfully uploaded 1"
+            " run\n\t\t• run_1\n\n:x:  *S3 Upload*: Failed uploading 1"
+            " run\n\t\t• run_2"
+        )
+
+        self.assertEqual(compiled_message, expected_message)
+
     def test_completed_upload_message_correct(self):
         compiled_message = slack.format_message(completed=["run_1", "run_2"])
 

--- a/tests/unit/test_slack.py
+++ b/tests/unit/test_slack.py
@@ -11,7 +11,7 @@ class TestFormatCompleteMessage(unittest.TestCase):
 
         expected_message = (
             ":white_check_mark:  *S3 Upload*: Successfully uploaded 2"
-            " runs\n\t• run_1\n\t• run_2"
+            " runs\n\t\t• run_1\n\t\t• run_2"
         )
 
         self.assertEqual(compiled_message, expected_message)
@@ -20,7 +20,8 @@ class TestFormatCompleteMessage(unittest.TestCase):
         compiled_message = slack.format_message(failed=["run_3", "run_4"])
 
         expected_message = (
-            ":x:  *S3 Upload*: Failed uploading 2 runs\n\t• run_3\n\t• run_4"
+            ":x:  *S3 Upload*: Failed uploading 2 runs\n\t\t• run_3\n\t\t•"
+            " run_4"
         )
 
         self.assertEqual(compiled_message, expected_message)
@@ -32,9 +33,9 @@ class TestFormatCompleteMessage(unittest.TestCase):
 
         expected_message = (
             ":white_check_mark:  *S3 Upload*: Successfully uploaded 2"
-            " runs\n\t• run_1\n\t• run_2\n\n"
+            " runs\n\t\t• run_1\n\t\t• run_2\n\n"
             ":x:  *S3 Upload*: Failed uploading 2 runs"
-            "\n\t• run_3\n\t• run_4"
+            "\n\t\t• run_3\n\t\t• run_4"
         )
 
         self.assertEqual(compiled_message, expected_message)

--- a/tests/unit/test_slack.py
+++ b/tests/unit/test_slack.py
@@ -11,7 +11,7 @@ class TestFormatCompleteMessage(unittest.TestCase):
 
         expected_message = (
             ":white_check_mark:  *S3 Upload*: Successfully uploaded 2"
-            " runs\n\t:black_square: run_1\n\t:black_square: run_2"
+            " runs\n\t• run_1\n\t• run_2"
         )
 
         self.assertEqual(compiled_message, expected_message)
@@ -20,8 +20,7 @@ class TestFormatCompleteMessage(unittest.TestCase):
         compiled_message = slack.format_message(failed=["run_3", "run_4"])
 
         expected_message = (
-            ":x:  *S3 Upload*: Failed uploading 2 runs"
-            "\n\t:black_square: run_3\n\t:black_square: run_4"
+            ":x:  *S3 Upload*: Failed uploading 2 runs\n\t• run_3\n\t• run_4"
         )
 
         self.assertEqual(compiled_message, expected_message)
@@ -33,9 +32,9 @@ class TestFormatCompleteMessage(unittest.TestCase):
 
         expected_message = (
             ":white_check_mark:  *S3 Upload*: Successfully uploaded 2"
-            " runs\n\t:black_square: run_1\n\t:black_square: run_2\n\n"
+            " runs\n\t• run_1\n\t• run_2\n\n"
             ":x:  *S3 Upload*: Failed uploading 2 runs"
-            "\n\t:black_square: run_3\n\t:black_square: run_4"
+            "\n\t• run_3\n\t• run_4"
         )
 
         self.assertEqual(compiled_message, expected_message)


### PR DESCRIPTION
- remove use of `TimeRotatingLogFile` for regular `logging.FileHandler` and manual handling of log file backups since CPython sucks and can't properly manage file rotation
  - log files now always written to `s3_upload.log.{YYYY-MM-DD}` and previous 5 days retained
  - added unit tests for new changes
- update Slack message formatting to use proper bullet points and nicer formatting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/s3_upload/49)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation**
	- Enhanced clarity in the README regarding logging, authentication, and configuration for the AWS S3 upload tool.
	- Updated logging section to specify log file naming conventions and management.
	- Expanded configuration details for monitoring directories.

- **New Features**
	- Introduced `--threads` argument for upload mode, allowing users to specify the number of threads.
	- Improved Slack message formatting for successful and failed uploads.
	- Added functionality to manage old log files, ensuring better organisation.

- **Bug Fixes**
	- Resolved potential authentication conflicts by enforcing single authentication method usage.

- **Tests**
	- Added tests for log file management and improved message formatting in Slack notifications.
	- Introduced tests for grammatical accuracy in Slack messages and enhanced log file handling in end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->